### PR TITLE
DEVOPS-166-LONGER-TIMEOUT

### DIFF
--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -58,6 +58,10 @@ on:
         required: true
         type: string
         description: "Application information storage table."
+      deploymentTimeout:
+        required: false
+        type: string
+        description: "Timeout for GitHub deployments"
     secrets:
       azureCredentials:
         required: true
@@ -73,7 +77,10 @@ jobs:
   AKS_Deploy:
     runs-on: ubuntu-latest
     continue-on-error: false
-    timeout-minutes: 25   
+    strategy:
+      matrix:
+        deploymentTimeout:
+        - ${{ inputs.deploymentTimeout }}
     steps:
       - id: getlatestrelease
         if: ${{ inputs.environment == 'production'}}
@@ -302,6 +309,7 @@ jobs:
         id: bakeproduction
 
       - name: Deploy to Azure ${{ inputs.environment }}
+        timeout-minutes: ${{ matrix.deploymentTimeout }}
         if: ${{ inputs.environment != 'production'}}
         uses: Azure/k8s-deploy@v1
         with:

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -60,8 +60,9 @@ on:
         description: "Application information storage table."
       deploymentTimeout:
         required: false
-        type: string
+        type: number
         description: "Timeout for GitHub deployments"
+        default: 20
     secrets:
       azureCredentials:
         required: true
@@ -309,7 +310,7 @@ jobs:
         id: bakeproduction
 
       - name: Deploy to Azure ${{ inputs.environment }}
-        timeout-minutes: ${{ matrix.deploymentTimeout }}
+        timeout-minutes: ${{ inputs.deploymentTimeout }}
         if: ${{ inputs.environment != 'production'}}
         uses: Azure/k8s-deploy@v1
         with:

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -78,10 +78,6 @@ jobs:
   AKS_Deploy:
     runs-on: ubuntu-latest
     continue-on-error: false
-    strategy:
-      matrix:
-        deploymentTimeout:
-        - ${{ inputs.deploymentTimeout }}
     steps:
       - id: getlatestrelease
         if: ${{ inputs.environment == 'production'}}

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -73,7 +73,7 @@ jobs:
   AKS_Deploy:
     runs-on: ubuntu-latest
     continue-on-error: false
-    timeout-minutes: 360    
+    timeout-minutes: 25   
     steps:
       - id: getlatestrelease
         if: ${{ inputs.environment == 'production'}}

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -73,7 +73,7 @@ jobs:
   AKS_Deploy:
     runs-on: ubuntu-latest
     continue-on-error: false
-    timeout-minutes: 25   
+    timeout-minutes: 360   
     steps:
       - id: getlatestrelease
         if: ${{ inputs.environment == 'production'}}

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -73,7 +73,7 @@ jobs:
   AKS_Deploy:
     runs-on: ubuntu-latest
     continue-on-error: false
-    timeout-minutes: 360   
+    timeout-minutes: 25   
     steps:
       - id: getlatestrelease
         if: ${{ inputs.environment == 'production'}}

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -62,7 +62,7 @@ on:
         required: false
         type: number
         description: "Timeout for GitHub deployments"
-        default: 20
+        default: 1
     secrets:
       azureCredentials:
         required: true

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -73,7 +73,7 @@ jobs:
   AKS_Deploy:
     runs-on: ubuntu-latest
     continue-on-error: false
-    timeout-minutes: 20     
+    timeout-minutes: 360    
     steps:
       - id: getlatestrelease
         if: ${{ inputs.environment == 'production'}}

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -62,7 +62,7 @@ on:
         required: false
         type: number
         description: "Timeout for GitHub deployments"
-        default: 1
+        default: 20
     secrets:
       azureCredentials:
         required: true


### PR DESCRIPTION
Increasing timeout on AKS_Deploy job from 20 minutes to 25 minutes to account for spot-the-difference-game deployments.