### PR TITLE
[DEVOPS] split out aks deploy workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Add DevOps team
+*                               @Andrews-McMeel-Universal/devops-engineers

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## Description
+
+_A summary of the changes_
+
+## Links
+
+_relevant links_
+
+- Jira Issue: DEVOPS-<num>

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: ".github/workflows"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -256,10 +256,11 @@ jobs:
         id: encrypt
         shell: bash
         run: |
-          containerRegistry="${{ steps.setenvs.outputs.containerRegistry }}"
-          echo "::add-mask::$containerRegistry"
-          containerRegistryEncrypted=$(gpg --symmetric --batch --passphrase "${{ secrets.registryPassword }}" --output - <(echo "$containerRegistry)" | base64 -w0)
+          containerRegistryEncrypted=$(gpg --symmetric --batch --passphrase "$PASSPHRASE" --output - <(echo "$VALUE)" | base64 -w0))
           echo "containerRegistryEncrypted=$containerRegistryEncrypted" >> $env:GITHUB_ENV
+        env:
+          VALUE: ${{ steps.setenvs.outputs.containerRegistry }}
+          PASSPHRASE: ${{ secrets.registryPassword }}
 
     outputs:
       appName: ${{ env.appName }}
@@ -348,10 +349,11 @@ jobs:
         id: decrypt
         shell: bash
         run: |
-          containerRegistryEncrypted="${{ needs.setup.outputs.containerRegistryEncrypted }}"
-          containerRegistry=$(gpg --decrypt --quiet --batch --passphrase "${{ secrets.registryPassword }}" --output - <(echo "$containerRegistryEncrypted" | base64 --decode))
-          echo "::add-mask::$containerRegistry"
+          containerRegistry=$(gpg --decrypt --quiet --batch --passphrase "$PASSPHRASE" --output - <(echo "$VALUE" | base64 --decode))
           echo "containerRegistry=$containerRegistry" >> $env:GITHUB_ENV
+        env:
+          VALUE: ${{ needs.setup.outputs.containerRegistryEncrypted }}
+          PASSPHRASE: ${{ secrets.registryPassword }}
 
       - name: Login to Azure Container Registry
         uses: Azure/docker-login@v1.0.1

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -415,6 +415,7 @@ jobs:
         with:
           name: bake-manifests-bundle
           path: ${{ steps.bake.outputs.manifestsBundle }}
+          retention-days: 1
 
     outputs:
       manifestsBundle: ${{ steps.bake.outputs.manifestsBundle }}
@@ -491,16 +492,11 @@ jobs:
       - name: Output summary
         run: |
           echo "### ${{ needs.setup.outputs.appName }} Deployment Details" >> $GITHUB_STEP_SUMMARY
-          echo "- ApplicationName:${{ needs.setup.outputs.appName }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Environment=${{ inputs.environment }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Version=${{ needs.setup.outputs.appVersion }}" >> $GITHUB_STEP_SUMMARY
-          echo "- KeyVault=${{ inputs.environmentKeyVault }}" >> $GITHUB_STEP_SUMMARY
-          echo "- HostName=${{ needs.setup.outputs.hostName }}" >> $GITHUB_STEP_SUMMARY
-          echo "- DomainName=${{ needs.setup.outputs.domainName }}" >> $GITHUB_STEP_SUMMARY
-          echo "- IngressFqdn=${{ needs.setup.outputs.ingress }}" >> $GITHUB_STEP_SUMMARY
-          echo "- HealthCheckPath=${{ needs.setup.outputs.appHealthCheck }}" >> $GITHUB_STEP_SUMMARY
-          echo "- AksIngress=${{ inputs.aksIngressFqdn }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Cluster=${{ inputs.clusterName }}" >> $GITHUB_STEP_SUMMARY
-          echo "- ClusterResourceGroup=${{ inputs.clusterResourceGroup }}" >> $GITHUB_STEP_SUMMARY
-          echo "- ConfigSecret=${{ needs.setup.outputs.configSecret }}" >> $GITHUB_STEP_SUMMARY
-          echo "- ConfigMap=${{ needs.setup.outputs.configMap }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Application Name**: ${{ needs.setup.outputs.appName }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Environment**: ${{ inputs.environment }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version**: ${{ needs.setup.outputs.appVersion }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Key Vault Name**: ${{ inputs.environmentKeyVault }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **FQDN**: ${{ needs.setup.outputs.ingress }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Cluster**: ${{ inputs.clusterName }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **ConfigSecret**: ${{ needs.setup.outputs.configSecret }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **ConfigMap**: ${{ needs.setup.outputs.configMap }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -424,9 +424,8 @@ jobs:
           connection_string: "AccountName=${{ inputs.storageAccountName }};AccountKey=${{ secrets.storageAccountKey }}"
 
       - name: Output summary
-        env:
-          SHELLCHECK_OPTS: "-e SC2059"
         run: |
+          # shellcheck disable=SC2086
           echo "### ${{ env.appName }} Deployment Details" >> $GITHUB_STEP_SUMMARY
           echo "- ApplicationName:${{ env.appName }}" >> $GITHUB_STEP_SUMMARY
           echo "- Environment=${{ inputs.environment }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -425,17 +425,17 @@ jobs:
 
       - name: Output summary
         run: |
-          echo "### \""${{ env.appName }}"\" Deployment Details" >> $GITHUB_STEP_SUMMARY
-          echo "- ApplicationName: \""${{ env.appName }}"\"" >> $GITHUB_STEP_SUMMARY
-          echo "- Environment: \""${{ inputs.environment }}"\"" >> $GITHUB_STEP_SUMMARY
-          echo "- Version: \""${{ env.appVersion }}"\"" >> $GITHUB_STEP_SUMMARY
-          echo "- KeyVault: \""${{ inputs.environmentKeyVault }}"\"" >> $GITHUB_STEP_SUMMARY
-          echo "- HostName: \""${{ env.hostName }}"\"" >> $GITHUB_STEP_SUMMARY
-          echo "- DomainName: \""${{ env.domainName }}"\"" >> $GITHUB_STEP_SUMMARY
-          echo "- IngressFqdn: \""${{ env.ingress }}"\"" >> $GITHUB_STEP_SUMMARY
-          echo "- HealthCheckPath: \""${{ env.appHealthCheck }}"\"" >> $GITHUB_STEP_SUMMARY
-          echo "- AksIngress: \""${{ inputs.aksIngressFqdn }}"\"" >> $GITHUB_STEP_SUMMARY
-          echo "- Cluster: \""${{ inputs.clusterName }}"\"" >> $GITHUB_STEP_SUMMARY
-          echo "- ClusterResourceGroup: \""${{ inputs.clusterResourceGroup }}"\"" >> $GITHUB_STEP_SUMMARY
-          echo "- ConfigSecret: \""${{ env.configSecret }}"\"" >> $GITHUB_STEP_SUMMARY
-          echo "- ConfigMap: \""${{ env.configMap }}"\"" >> $GITHUB_STEP_SUMMARY
+          echo '### \""${{ env.appName }}"\" Deployment Details' >> $GITHUB_STEP_SUMMARY
+          echo '- ApplicationName: \""${{ env.appName }}"\"' >> $GITHUB_STEP_SUMMARY
+          echo '- Environment: \""${{ inputs.environment }}"\"' >> $GITHUB_STEP_SUMMARY
+          echo '- Version: \""${{ env.appVersion }}"\"' >> $GITHUB_STEP_SUMMARY
+          echo '- KeyVault: \""${{ inputs.environmentKeyVault }}"\"' >> $GITHUB_STEP_SUMMARY
+          echo '- HostName: \""${{ env.hostName }}"\"' >> $GITHUB_STEP_SUMMARY
+          echo '- DomainName: \""${{ env.domainName }}"\"' >> $GITHUB_STEP_SUMMARY
+          echo '- IngressFqdn: \""${{ env.ingress }}"\"' >> $GITHUB_STEP_SUMMARY
+          echo '- HealthCheckPath: \""${{ env.appHealthCheck }}"\"' >> $GITHUB_STEP_SUMMARY
+          echo '- AksIngress: \""${{ inputs.aksIngressFqdn }}"\"' >> $GITHUB_STEP_SUMMARY
+          echo '- Cluster: \""${{ inputs.clusterName }}"\"' >> $GITHUB_STEP_SUMMARY
+          echo '- ClusterResourceGroup: \""${{ inputs.clusterResourceGroup }}"\"' >> $GITHUB_STEP_SUMMARY
+          echo '- ConfigSecret: \""${{ env.configSecret }}"\"' >> $GITHUB_STEP_SUMMARY
+          echo '- ConfigMap: \""${{ env.configMap }}"\"' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -145,6 +145,7 @@ jobs:
           $chartYamlPath = Join-Path $basePath ${{ inputs.chartsPath }} "Chart.yaml"
           $chartConfig= Get-Envs -PathToYaml $chartYamlPath
           $containerRegistry = $appConfig.image.repository
+          $containerRegistry = $(gpg --symmetric --batch --passphrase "${{ secrets.registryPassword }}" --output - <(echo "$containerRegistry")
           $appName = $chartConfig.name
           $appVersion = $chartConfig.appVersion
           $appHealthCheck = $appconfig.deployment.healthCheckPath
@@ -177,7 +178,6 @@ jobs:
           
           $release = "$appName-${{ github.sha }}".Substring(0,53)
           $release=($release -replace '[^-\p{L}\p{Nd}]', '').ToLower() -replace '^-', '' -replace '-$', ''
-
           echo "appName=$appName" >> $env:GITHUB_ENV
           echo "appVersion=$appVersion" >> $env:GITHUB_ENV
           echo "appHealthCheck=$appHealthCheck" >> $env:GITHUB_ENV
@@ -336,10 +336,15 @@ jobs:
             echo "buildArguments=$buildArguments" >> $env:GITHUB_ENV
           azPSVersion: 'latest'
 
+      - name: Decrypt Azure Container Registry value
+        run: |
+          containerRegistry=$(gpg --decrypt --quiet --batch --passphrase "${{ secrets.registryPassword }}" --output - <(echo "${{ needs.setup.outputs.containerRegistry }}" | base64 --decode))
+          echo "containerRegistry=$containerRegistry" >> $env:GITHUB_ENV
+
       - name: Login to Azure Container Registry
         uses: Azure/docker-login@v1.0.1
         with:
-          login-server: "${{ needs.setup.outputs.containerRegistry }}"
+          login-server: "${{ env.containerRegistry }}"
           username: ${{ secrets.registryUserName }}
           password: ${{ secrets.registryPassword }}
 

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -255,7 +255,6 @@ jobs:
       - name: Encrypt Azure Container Registry value
         run: |
           containerRegistry=$(gpg --symmetric --batch --passphrase "${{ secrets.registryPassword }}" --output - <(echo "${{ steps.setenvs.outputs.containerRegistry }}"))
-          echo "::add-mask::$containerRegistry"
           echo "containerRegistry=$containerRegistry" >> $env:GITHUB_ENV
 
     outputs:

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -346,13 +346,6 @@ jobs:
           docker build ${{ inputs.dockerFilePath }} ${{ env.buildArguments }} -t "${{ secrets.registryHostName  }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
           docker push "${{ secrets.registryHostName }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
 
-  deploy:
-    name: 'Deploy to AKS cluster'
-    needs: [setup,build]
-    runs-on: ubuntu-latest
-    continue-on-error: false
-    environment: ${{ inputs.environment }}
-    steps:
       - name: Create values override file
         run: |
           WEB_AUTHENTICATION="${{ inputs.webAuthentication }}"
@@ -417,6 +410,28 @@ jobs:
             ingress.host:${{ needs.setup.outputs.ingress }}
             autoscaling.maxReplicas:${{ inputs.maximumReplicas }}
 
+      - name: Upload bake-manifests-bundle artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: bake-manifests-bundle
+          path: ${{ steps.bake.outputs.manifestsBundle }}
+
+    outputs:
+      manifestsBundle: ${{ steps.bake.outputs.manifestsBundle }}
+
+  deploy:
+    name: 'Deploy to AKS cluster'
+    needs: [setup,build]
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    environment: ${{ inputs.environment }}
+    steps:
+      - name: Download bake-manifests-bundle artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: bake-manifests-bundle
+          path: ${{ needs.build.outputs.manifestsBundle }}
+
       - name: Login via Az module
         uses: azure/login@v1.4.7
         with:
@@ -434,7 +449,7 @@ jobs:
         uses: Azure/k8s-deploy@v4.9
         with:
           namespace: ${{ inputs.environment }}
-          manifests: ${{ steps.bake.outputs.manifestsBundle }}
+          manifests: ${{ needs.build.outputs.manifestsBundle }}
           images: |
             "${{ secrets.registryHostName }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
           imagePullSecrets: |

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -203,7 +203,8 @@ jobs:
         uses: azure/powershell@v1.2.0
         with:
           inlineScript: |
-            $envSecrets = (Get-AzKeyVaultSecret -VaultName "${{ inputs.environmentKeyVault }}"  | Where-Object {($_.ContentType -contains 'Env') -or ($_.ContentType -contains 'BuildArg Env')}).Name
+            $KeyVaultName = "${{ inputs.environmentKeyVault }}"
+            $envSecrets = (Get-AzKeyVaultSecret -VaultName $KeyVaultName  | Where-Object {($_.ContentType -contains 'Env') -or ($_.ContentType -contains 'BuildArg Env')}).Name
             $envSecrets | ForEach-Object {
                 $envName = $_.ToUpper()
                 $envName = $envName.Replace("-","_")
@@ -302,7 +303,8 @@ jobs:
         uses: azure/powershell@v1.2.0
         with:
           inlineScript: |
-            $envSecrets = (Get-AzKeyVaultSecret -VaultName "${{ inputs.environmentKeyVault }}"  | Where-Object {($_.ContentType -contains 'Env') -or ($_.ContentType -contains 'BuildArg Env')}).Name
+            $KeyVaultName = "${{ inputs.environmentKeyVault }}"
+            $envSecrets = (Get-AzKeyVaultSecret -VaultName $KeyVaultName  | Where-Object {($_.ContentType -contains 'Env') -or ($_.ContentType -contains 'BuildArg Env')}).Name
             $envSecrets | ForEach-Object {
                 $envName = $_.ToUpper()
                 $envName = $envName.Replace("-","_")
@@ -316,7 +318,8 @@ jobs:
         uses: azure/powershell@v1.2.0
         with:
           inlineScript: |
-            $buildSecrets = (Get-AzKeyVaultSecret -VaultName "${{ inputs.environmentKeyVault }}"  | Where-Object {($_.ContentType -contains 'BuildArg') -or ($_.ContentType -contains 'BuildArg Env')}).Name
+            $KeyVaultName = "${{ inputs.environmentKeyVault }}"
+            $buildSecrets = (Get-AzKeyVaultSecret -VaultName $KeyVaultName  | Where-Object {($_.ContentType -contains 'BuildArg') -or ($_.ContentType -contains 'BuildArg Env')}).Name
             if ($buildSecrets.Count -gt 0) {
                 $buildArgPredicate = ' --build-arg '
             }
@@ -326,7 +329,7 @@ jobs:
             $buildSecrets | ForEach-Object {
                 $argName = $_.ToUpper()
                 $argName = $argName.Replace("-","_")
-                $argSecret = (Get-AzKeyVaultSecret -VaultName "${{ inputs.environmentKeyVault }}" -Name $_).secretvalue | ConvertFrom-SecureString -AsPlainText
+                $argSecret = (Get-AzKeyVaultSecret -VaultName $KeyVaultName -Name $_).secretvalue | ConvertFrom-SecureString -AsPlainText
                 $buildArguments = $buildArguments + $buildArgPredicate + $argName + "=" + $argSecret
             }
 

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -247,7 +247,7 @@ jobs:
       - name: Create k8s Image Pull Secret
         uses: Azure/k8s-create-secret@v4.0
         with:
-          container-registry-url: "${{ env.containerRegistry }}"
+          container-registry-url: "${{ steps.setenvs.outputs.containerRegistry }}"
           container-registry-username: ${{ secrets.registryUserName  }}
           container-registry-password: ${{ secrets.registryPassword  }}
           secret-name: "${{ env.imagePullSecret }}"
@@ -364,8 +364,8 @@ jobs:
 
       - name: Build & Push Docker Image
         run: |
-          docker build ${{ inputs.dockerFilePath }} ${{ env.buildArguments }} -t "${{ needs.setup.outputs.containerRegistry  }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
-          docker push "${{ needs.setup.outputs.containerRegistry }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
+          docker build ${{ inputs.dockerFilePath }} ${{ env.buildArguments }} -t "${{ env.containerRegistry  }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
+          docker push "${{ env.containerRegistry }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
 
   deploy:
     name: 'Deploy to AKS cluster'
@@ -423,6 +423,16 @@ jobs:
           EOF
           fi
 
+      - name: Decrypt containerRegistry value
+        id: decrypt
+        shell: bash
+        run: |
+          containerRegistry=$(gpg --decrypt --quiet --batch --passphrase "$PASSPHRASE" --output - <(echo "$VALUE" | base64 --decode))
+          echo "containerRegistry=$containerRegistry" >> $env:GITHUB_ENV
+        env:
+          VALUE: ${{ needs.setup.outputs.containerRegistryEncrypted }}
+          PASSPHRASE: ${{ secrets.registryPassword }}
+
       - name: Bake Helm Templates
         id: bake
         uses: azure/k8s-bake@v2.2
@@ -433,7 +443,7 @@ jobs:
           helm-version: 'latest'
           overrideFiles: ./values-override.yaml
           overrides: |
-            image.repository:${{ needs.setup.outputs.containerRegistry }}/${{ inputs.dockerImageName }}
+            image.repository:${{ env.containerRegistry }}/${{ inputs.dockerImageName }}
             image.tag:${{ inputs.dockerImageTag }}
             ingress.host:${{ needs.setup.outputs.ingress }}
             autoscaling.maxReplicas:${{ inputs.maximumReplicas }}
@@ -457,7 +467,7 @@ jobs:
           namespace: ${{ inputs.environment }}
           manifests: ${{ steps.bake.outputs.manifestsBundle }}
           images: |
-            "${{ needs.setup.outputs.containerRegistry }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
+            "${{ env.containerRegistry }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
           imagePullSecrets: |
             "${{ needs.setup.outputs.imagePullSecret }}"
           pull-images: false

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -192,6 +192,7 @@ jobs:
           echo "ingressWhitelist=$ingressWhitelist" >> $env:GITHUB_ENV
           echo "adminIngressWhitelist=$adminIngressWhitelist" >> $env:GITHUB_ENV
           echo "release=$release" >> $env:GITHUB_ENV
+          
     outputs:
       appName: ${{ env.appName }}
       appVersion: ${{ env.appVersion }}
@@ -322,9 +323,26 @@ jobs:
     continue-on-error: false
     environment: ${{ inputs.environment }}
     steps:
+      - name: Checkout if Staging or Development deployment
+        if: ${{ inputs.environment != 'production'}}
+        uses: actions/checkout@v3.2.0
+
+      - name: Get latest release if production deployment
+        if: ${{ inputs.environment == 'production'}}
+        id: getlatestrelease
+        uses: thebritican/fetch-latest-release@v2.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout Latest release if Production deployment
+        if: ${{ inputs.environment == 'production'}}
+        uses: actions/checkout@v3.2.0
+        with: 
+          ref: ${{ steps.getlatestrelease.outputs.tag_name }}
+
       - name: Build & Push Docker Image
         run: |
-          docker build ../${{ inputs.dockerFilePath }} ${{ needs.prepare-build.outputs.buildArguments }} -t "${{ needs.setup-environment.outputs.containerRegistry  }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
+          docker build ${{ inputs.dockerFilePath }} ${{ needs.prepare-build.outputs.buildArguments }} -t "${{ needs.setup-environment.outputs.containerRegistry  }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
           docker push "${{ needs.setup-environment.outputs.containerRegistry }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
 
   deploy:

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -258,7 +258,7 @@ jobs:
         run: |
           containerRegistry="${{ steps.setenvs.outputs.containerRegistry }}"
           echo "::add-mask::$containerRegistry"
-          containerRegistryEncrypted=$(gpg --symmetric --batch --passphrase "${{ secrets.registryPassword }}" --output - <(echo "$containerRegistry) | base64 -w0)
+          containerRegistryEncrypted=$(gpg --symmetric --batch --passphrase "${{ secrets.registryPassword }}" --output - <(echo "$containerRegistry)" | base64 -w0)
           echo "containerRegistryEncrypted=$containerRegistryEncrypted" >> $env:GITHUB_ENV
 
     outputs:

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -439,17 +439,16 @@ jobs:
           configSecret=${{ env.configSecret }}
           configMap=${{ env.configMap }}
 
-          echo "### $appName Deployment Details" >> $GITHUB_STEP_SUMMARY
-          echo "- ApplicationName: $appName" >> $GITHUB_STEP_SUMMARY
-          echo "- Environment: $environment" >> $GITHUB_STEP_SUMMARY
-          echo "- Version: $appVersion" >> $GITHUB_STEP_SUMMARY
-          echo "- KeyVault: $environmentKeyVault" >> $GITHUB_STEP_SUMMARY
-          echo "- HostName: $hostName" >> $GITHUB_STEP_SUMMARY
-          echo "- DomainName: $domainName" >> $GITHUB_STEP_SUMMARY
-          echo "- IngressFqdn: $ingress" >> $GITHUB_STEP_SUMMARY
-          echo "- HealthCheckPath: $appHealthCheck" >> $GITHUB_STEP_SUMMARY
-          echo "- AksIngress: $aksIngressFqdn" >> $GITHUB_STEP_SUMMARY
-          echo "- Cluster: $clusterName" >> $GITHUB_STEP_SUMMARY
-          echo "- ClusterResourceGroup: $clusterResourceGroup" >> $GITHUB_STEP_SUMMARY
-          echo "- ConfigSecret: $configSecret" >> $GITHUB_STEP_SUMMARY
-          echo "- ConfigMap: $configMap" >> $GITHUB_STEP_SUMMARY
+          echo "### \"$appName\" Deployment Details" >> $GITHUB_STEP_SUMMARY
+          echo "- Environment: \"$environment\"" >> $GITHUB_STEP_SUMMARY
+          echo "- Version: \"$appVersion\"" >> $GITHUB_STEP_SUMMARY
+          echo "- KeyVault: \"$environmentKeyVault\"" >> $GITHUB_STEP_SUMMARY
+          echo "- HostName: \"$hostName\"" >> $GITHUB_STEP_SUMMARY
+          echo "- DomainName: \"$domainName\"" >> $GITHUB_STEP_SUMMARY
+          echo "- IngressFqdn: \"$ingress\"" >> $GITHUB_STEP_SUMMARY
+          echo "- HealthCheckPath: \"$appHealthCheck\"" >> $GITHUB_STEP_SUMMARY
+          echo "- AksIngress: \"$aksIngressFqdn\"" >> $GITHUB_STEP_SUMMARY
+          echo "- Cluster: \"$clusterName\"" >> $GITHUB_STEP_SUMMARY
+          echo "- ClusterResourceGroup: \"$clusterResourceGroup\"" >> $GITHUB_STEP_SUMMARY
+          echo "- ConfigSecret: \"$configSecret\"" >> $GITHUB_STEP_SUMMARY
+          echo "- ConfigMap: \"$configMap\"" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -425,17 +425,31 @@ jobs:
 
       - name: Output summary
         run: |
-          echo '### \""${{ env.appName }}"\" Deployment Details' >> $GITHUB_STEP_SUMMARY
-          echo '- ApplicationName: \""${{ env.appName }}"\"' >> $GITHUB_STEP_SUMMARY
-          echo '- Environment: \""${{ inputs.environment }}"\"' >> $GITHUB_STEP_SUMMARY
-          echo '- Version: \""${{ env.appVersion }}"\"' >> $GITHUB_STEP_SUMMARY
-          echo '- KeyVault: \""${{ inputs.environmentKeyVault }}"\"' >> $GITHUB_STEP_SUMMARY
-          echo '- HostName: \""${{ env.hostName }}"\"' >> $GITHUB_STEP_SUMMARY
-          echo '- DomainName: \""${{ env.domainName }}"\"' >> $GITHUB_STEP_SUMMARY
-          echo '- IngressFqdn: \""${{ env.ingress }}"\"' >> $GITHUB_STEP_SUMMARY
-          echo '- HealthCheckPath: \""${{ env.appHealthCheck }}"\"' >> $GITHUB_STEP_SUMMARY
-          echo '- AksIngress: \""${{ inputs.aksIngressFqdn }}"\"' >> $GITHUB_STEP_SUMMARY
-          echo '- Cluster: \""${{ inputs.clusterName }}"\"' >> $GITHUB_STEP_SUMMARY
-          echo '- ClusterResourceGroup: \""${{ inputs.clusterResourceGroup }}"\"' >> $GITHUB_STEP_SUMMARY
-          echo '- ConfigSecret: \""${{ env.configSecret }}"\"' >> $GITHUB_STEP_SUMMARY
-          echo '- ConfigMap: \""${{ env.configMap }}"\"' >> $GITHUB_STEP_SUMMARY
+          ApplicationName=${{ env.appName }}
+          Environment=${{ inputs.environment }}
+          Version=${{ env.appVersion }}
+          KeyVault=${{ inputs.environmentKeyVault }}
+          HostName=${{ env.hostName }}
+          DomainName=${{ env.domainName }}
+          IngressFqdn=${{ env.ingress }}
+          HealthCheckPath=${{ env.appHealthCheck }}
+          AksIngress=${{ inputs.aksIngressFqdn }}
+          Cluster=${{ inputs.clusterName }}
+          ClusterResourceGroup=${{ inputs.clusterResourceGroup }}
+          ConfigSecret=${{ env.configSecret }}
+          ConfigMap=${{ env.configMap }}
+
+          echo "### $appName Deployment Details" >> $GITHUB_STEP_SUMMARY
+          echo "- ApplicationName: $appName" >> $GITHUB_STEP_SUMMARY
+          echo "- Environment: $environment" >> $GITHUB_STEP_SUMMARY
+          echo "- Version: $appVersion" >> $GITHUB_STEP_SUMMARY
+          echo "- KeyVault: $environmentKeyVault" >> $GITHUB_STEP_SUMMARY
+          echo "- HostName: $hostName" >> $GITHUB_STEP_SUMMARY
+          echo "- DomainName: $domainName" >> $GITHUB_STEP_SUMMARY
+          echo "- IngressFqdn: $ingress" >> $GITHUB_STEP_SUMMARY
+          echo "- HealthCheckPath: $appHealthCheck" >> $GITHUB_STEP_SUMMARY
+          echo "- AksIngress: $aksIngressFqdn" >> $GITHUB_STEP_SUMMARY
+          echo "- Cluster: $clusterName" >> $GITHUB_STEP_SUMMARY
+          echo "- ClusterResourceGroup: $clusterResourceGroup" >> $GITHUB_STEP_SUMMARY
+          echo "- ConfigSecret: $configSecret" >> $GITHUB_STEP_SUMMARY
+          echo "- ConfigMap: $configMap" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -98,8 +98,8 @@ on:
         required: false
 
 jobs:
-  setup-environment:
-    name: 'Prepare environment'
+  setup:
+    name: 'Prepare for build'
     runs-on: ubuntu-latest
     continue-on-error: false
     environment: ${{ inputs.environment }}
@@ -192,7 +192,45 @@ jobs:
           echo "ingressWhitelist=$ingressWhitelist" >> $env:GITHUB_ENV
           echo "adminIngressWhitelist=$adminIngressWhitelist" >> $env:GITHUB_ENV
           echo "release=$release" >> $env:GITHUB_ENV
-          
+
+      - name: Set target AKS cluster
+        uses: Azure/aks-set-context@v3.2
+        with:
+          cluster-name: ${{ inputs.clusterName }}
+          resource-group: ${{ inputs.clusterResourceGroup }}
+
+      - name: Switch to ${{ inputs.environment }} Namespace
+        run: kubectl config set-context --current --namespace="${{ inputs.environment }}"
+
+      - name: Apply configMap
+        if: ${{ env.configMap != null }}
+        uses: swdotcom/update-and-apply-kubernetes-configs@v1.2.0
+        with:
+          k8-config-file-paths: deployments/k8s/config-${{ inputs.environment }}.yaml
+
+      - name: Add GitHub secrets to k8s
+        shell: pwsh
+        run: |
+          if (kubectl get secret | Select-String "${{ env.configSecret }}") {
+            kubectl delete secret "${{ env.configSecret }}"
+          }
+          kubectl create secret generic "${{ env.configSecret }}" --from-env-file .env
+
+          if ( "${{ inputs.webAuthentication }}" -eq "true") {
+            if (kubectl get secret | Select-String "${{ env.appName }}-basic-auth") {
+              kubectl delete secret "${{ env.appName }}-basic-auth"
+            }
+            htpasswd -cb auth "${{ secrets.webAuthenticationUsername }}" "${{ secrets.webAuthenticationPassword }}"
+            kubectl create secret generic "${{ env.appName }}-basic-auth" --from-file=auth
+          }
+
+      - name: Create k8s Image Pull Secret
+        uses: Azure/k8s-create-secret@v4.0
+        with:
+          container-registry-url: "${{ needs.setup.outputs.containerRegistry }}"
+          container-registry-username: ${{ secrets.registryUserName  }}
+          container-registry-password: ${{ secrets.registryPassword  }}
+          secret-name: "${{ needs.setup.outputs.imagePullSecret }}"
     outputs:
       appName: ${{ env.appName }}
       appVersion: ${{ env.appVersion }}
@@ -209,13 +247,30 @@ jobs:
       adminIngressWhitelist: ${{ env.adminIngressWhitelist }}
       release: ${{ env.release }}
 
-  prepare-build:
-    name: 'Prepare for Docker Image Build'
+  build:
+    name: 'Build Docker Image'
     runs-on: ubuntu-latest
-    needs: [setup-environment]
+    needs: [setup]
     continue-on-error: false
     environment: ${{ inputs.environment }}
     steps:
+      - name: Checkout if Staging or Development deployment
+        if: ${{ inputs.environment != 'production'}}
+        uses: actions/checkout@v3.2.0
+
+      - name: Get latest release if production deployment
+        if: ${{ inputs.environment == 'production'}}
+        id: getlatestrelease
+        uses: thebritican/fetch-latest-release@v2.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout Latest release if Production deployment
+        if: ${{ inputs.environment == 'production'}}
+        uses: actions/checkout@v3.2.0
+        with: 
+          ref: ${{ steps.getlatestrelease.outputs.tag_name }}
+
       - name: Login via Az module
         uses: azure/login@v1.4.7
         with:
@@ -271,83 +326,18 @@ jobs:
       - name: Login to Azure Container Registry
         uses: Azure/docker-login@v1.0.1
         with:
-          login-server: "${{ needs.setup-environment.outputs.containerRegistry }}"
+          login-server: "${{ needs.setup.outputs.containerRegistry }}"
           username: ${{ secrets.registryUserName }}
           password: ${{ secrets.registryPassword }}
 
-      - name: Set target AKS cluster
-        uses: Azure/aks-set-context@v3.2
-        with:
-          cluster-name: ${{ inputs.clusterName }}
-          resource-group: ${{ inputs.clusterResourceGroup }}
-
-      - name: Switch to ${{ inputs.environment }} Namespace
-        run: kubectl config set-context --current --namespace="${{ inputs.environment }}"
-
-      - name: Apply configMap
-        if: ${{ needs.setup-environment.outputs.configMap != null }}
-        uses: swdotcom/update-and-apply-kubernetes-configs@v1.2.0
-        with:
-          k8-config-file-paths: deployments/k8s/config-${{ inputs.environment }}.yaml
-
-      - name: Add GitHub secrets to k8s
-        shell: pwsh
-        run: |
-          if (kubectl get secret | Select-String "${{ needs.setup-environment.outputs.configSecret }}") {
-            kubectl delete secret "${{ needs.setup-environment.outputs.configSecret }}"
-          }
-          kubectl create secret generic "${{ needs.setup-environment.outputs.configSecret }}" --from-env-file .env
-
-          if ( "${{ inputs.webAuthentication }}" -eq "true") {
-            if (kubectl get secret | Select-String "${{ needs.setup-environment.outputs.appName }}-basic-auth") {
-              kubectl delete secret "${{ needs.setup-environment.outputs.appName }}-basic-auth"
-            }
-            htpasswd -cb auth "${{ secrets.webAuthenticationUsername }}" "${{ secrets.webAuthenticationPassword }}"
-            kubectl create secret generic "${{ needs.setup-environment.outputs.appName }}-basic-auth" --from-file=auth
-          }
-
-      - name: Create k8s Image Pull Secret
-        uses: Azure/k8s-create-secret@v4.0
-        with:
-          container-registry-url: "${{ needs.setup-environment.outputs.containerRegistry }}"
-          container-registry-username: ${{ secrets.registryUserName  }}
-          container-registry-password: ${{ secrets.registryPassword  }}
-          secret-name: "${{ needs.setup-environment.outputs.imagePullSecret }}"
-    outputs:
-      buildArguments: ${{ env.buildArguments }}
-
-  build:
-    name: 'Build Docker Image'
-    runs-on: ubuntu-latest
-    needs: [setup-environment,prepare-build]
-    continue-on-error: false
-    environment: ${{ inputs.environment }}
-    steps:
-      - name: Checkout if Staging or Development deployment
-        if: ${{ inputs.environment != 'production'}}
-        uses: actions/checkout@v3.2.0
-
-      - name: Get latest release if production deployment
-        if: ${{ inputs.environment == 'production'}}
-        id: getlatestrelease
-        uses: thebritican/fetch-latest-release@v2.0.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout Latest release if Production deployment
-        if: ${{ inputs.environment == 'production'}}
-        uses: actions/checkout@v3.2.0
-        with: 
-          ref: ${{ steps.getlatestrelease.outputs.tag_name }}
-
       - name: Build & Push Docker Image
         run: |
-          docker build ${{ inputs.dockerFilePath }} ${{ needs.prepare-build.outputs.buildArguments }} -t "${{ needs.setup-environment.outputs.containerRegistry  }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
-          docker push "${{ needs.setup-environment.outputs.containerRegistry }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
+          docker build ${{ inputs.dockerFilePath }} ${{ env.buildArguments }} -t "${{ needs.setup.outputs.containerRegistry  }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
+          docker push "${{ needs.setup.outputs.containerRegistry }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
 
   deploy:
     name: 'Deploy to AKS cluster'
-    needs: [setup-environment,prepare-build,build]
+    needs: [setup,build]
     runs-on: ubuntu-latest
     continue-on-error: false
     environment: ${{ inputs.environment }}
@@ -355,16 +345,16 @@ jobs:
       - name: Create values override file
         run: |
           WEB_AUTHENTICATION="${{ inputs.webAuthentication }}"
-          INGRESS_WHITELIST_ENV="${{ needs.setup-environment.outputs.ingressWhitelist }}"
-          ADMIN_INGRESS_WHITELIST_ENV="${{ needs.setup-environment.outputs.adminIngressWhitelist }}"
+          INGRESS_WHITELIST_ENV="${{ needs.setup.outputs.ingressWhitelist }}"
+          ADMIN_INGRESS_WHITELIST_ENV="${{ needs.setup.outputs.adminIngressWhitelist }}"
           if [[ -n "${INGRESS_WHITELIST_ENV}" ]] ; then
-            INGRESS_WHITELIST="${{ needs.setup-environment.outputs.ingressWhitelist }}"
+            INGRESS_WHITELIST="${{ needs.setup.outputs.ingressWhitelist }}"
           else
             INGRESS_WHITELIST="${{ inputs.ingressWhitelist }}"
           fi
 
           if [[ -n "${ADMIN_INGRESS_WHITELIST_ENV}" ]] ; then
-            ADMIN_INGRESS_WHITELIST="${{ needs.setup-environment.outputs.adminIngressWhitelist }}"
+            ADMIN_INGRESS_WHITELIST="${{ needs.setup.outputs.adminIngressWhitelist }}"
           else
             ADMIN_INGRESS_WHITELIST="${{ inputs.adminIngressWhitelist }}"
           fi
@@ -376,7 +366,7 @@ jobs:
               nginx.ingress.kubernetes.io/limit-whitelist: "207.67.20.252"
               nginx.ingress.kubernetes.io/whitelist-source-range: "${INGRESS_WHITELIST}"
               nginx.ingress.kubernetes.io/auth-type: "basic"
-              nginx.ingress.kubernetes.io/auth-secret: "${{ needs.setup-environment.outputs.appName }}-basic-auth"
+              nginx.ingress.kubernetes.io/auth-secret: "${{ needs.setup.outputs.appName }}-basic-auth"
               nginx.ingress.kubernetes.io/auth-realm: "Authentication Required"
           adminingress:
             annotations:
@@ -407,14 +397,26 @@ jobs:
         with:
           renderEngine: 'helm'
           helmChart: ${{ inputs.chartsPath }}
-          releaseName: ${{ needs.setup-environment.outputs.release }}
+          releaseName: ${{ needs.setup.outputs.release }}
           helm-version: 'latest'
           overrideFiles: ./values-override.yaml
           overrides: |
-            image.repository:${{ needs.setup-environment.outputs.containerRegistry }}/${{ inputs.dockerImageName }}
+            image.repository:${{ needs.setup.outputs.containerRegistry }}/${{ inputs.dockerImageName }}
             image.tag:${{ inputs.dockerImageTag }}
-            ingress.host:${{ needs.setup-environment.outputs.ingress }}
+            ingress.host:${{ needs.setup.outputs.ingress }}
             autoscaling.maxReplicas:${{ inputs.maximumReplicas }}
+
+      - name: Login via Az module
+        uses: azure/login@v1.4.7
+        with:
+          creds: "${{ secrets.azureCredentials }}"
+          enable-AzPSSession: true
+
+      - name: Set target AKS cluster
+        uses: Azure/aks-set-context@v3.2
+        with:
+          cluster-name: ${{ inputs.clusterName }}
+          resource-group: ${{ inputs.clusterResourceGroup }}
 
       - name: Deploy to Azure ${{ inputs.environment }}
         timeout-minutes: ${{ inputs.deploymentTimeout }}
@@ -423,14 +425,14 @@ jobs:
           namespace: ${{ inputs.environment }}
           manifests: ${{ steps.bake.outputs.manifestsBundle }}
           images: |
-            "${{ needs.setup-environment.outputs.containerRegistry }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
+            "${{ needs.setup.outputs.containerRegistry }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
           imagePullSecrets: |
-            "${{ needs.setup-environment.outputs.imagePullSecret }}"
+            "${{ needs.setup.outputs.imagePullSecret }}"
           pull-images: false
 
-  update-dns:
-    name: Update DNS record
-    needs: [setup-environment,prepare-build,build,deploy]
+  update-records:
+    name: Update deployment records
+    needs: [setup,build,deploy]
     runs-on: ubuntu-latest
     continue-on-error: false
     environment: ${{ inputs.environment }}
@@ -440,40 +442,33 @@ jobs:
         with:
           inlineScript: |
             $NewRecords = New-AzDnsRecordConfig -Cname ${{ inputs.aksIngressFqdn }};
-            New-AzDnsRecordSet -Name "${{ needs.setup-environment.outputs.hostName }}" -RecordType CNAME -ZoneName "${{ needs.setup-environment.outputs.domainName }}" -ResourceGroupName ${{ inputs.dnsResourceGroup }} -Ttl 3600 -DnsRecords $NewRecords -Overwrite;
+            New-AzDnsRecordSet -Name "${{ needs.setup.outputs.hostName }}" -RecordType CNAME -ZoneName "${{ needs.setup.outputs.domainName }}" -ResourceGroupName ${{ inputs.dnsResourceGroup }} -Ttl 3600 -DnsRecords $NewRecords -Overwrite;
           azPSVersion: "latest"
 
-  deployment-summary:
-    name: Record deployment information
-    needs: [setup-environment,prepare-build,build,deploy,update-dns]
-    runs-on: ubuntu-latest
-    continue-on-error: false
-    environment: ${{ inputs.environment }}
-    steps:
       - name: Record deployment information in Azure Storage Table ${{ inputs.appInfoTableName }}
         uses: LadyCailin/azure-table-storage-upload@v1.0.1
         with:
           table_name: "${{ inputs.appInfoTableName }}"
           partition_key: "${{ inputs.repositoryName }}"
           row_key: "${{ inputs.environment }}"
-          data: "ApplicationName=${{ needs.setup-environment.outputs.appName }} Version=${{ needs.setup-environment.outputs.appVersion }} KeyVault=${{ inputs.environmentKeyVault }} HostName=${{ needs.setup-environment.outputs.hostName }} DomainName=${{ needs.setup-environment.outputs.domainName }} IngressFqdn=${{ needs.setup-environment.outputs.ingress }} HealthCheckPath=${{ needs.setup-environment.outputs.appHealthCheck }} AksIngress=${{ inputs.aksIngressFqdn }} Cluster=${{ inputs.clusterName }} ClusterResourceGroup=${{ inputs.clusterResourceGroup }} ConfigSecret=${{needs.setup-environment.outputs.configSecret }} ConfigMap=${{ needs.setup-environment.outputs.configMap }} LastDeploy=${{ needs.setup-environment.outputs.date }}"
+          data: "ApplicationName=${{ needs.setup.outputs.appName }} Version=${{ needs.setup.outputs.appVersion }} KeyVault=${{ inputs.environmentKeyVault }} HostName=${{ needs.setup.outputs.hostName }} DomainName=${{ needs.setup.outputs.domainName }} IngressFqdn=${{ needs.setup.outputs.ingress }} HealthCheckPath=${{ needs.setup.outputs.appHealthCheck }} AksIngress=${{ inputs.aksIngressFqdn }} Cluster=${{ inputs.clusterName }} ClusterResourceGroup=${{ inputs.clusterResourceGroup }} ConfigSecret=${{needs.setup.outputs.configSecret }} ConfigMap=${{ needs.setup.outputs.configMap }} LastDeploy=${{ needs.setup.outputs.date }}"
           if_exists: 'replace'
           extra_args: ''
           connection_string: "AccountName=${{ inputs.storageAccountName }};AccountKey=${{ secrets.storageAccountKey }}"
 
       - name: Output summary
         run: |
-          echo "### ${{ needs.setup-environment.outputs.appName }} Deployment Details" >> $GITHUB_STEP_SUMMARY
-          echo "- ApplicationName:${{ needs.setup-environment.outputs.appName }}" >> $GITHUB_STEP_SUMMARY
+          echo "### ${{ needs.setup.outputs.appName }} Deployment Details" >> $GITHUB_STEP_SUMMARY
+          echo "- ApplicationName:${{ needs.setup.outputs.appName }}" >> $GITHUB_STEP_SUMMARY
           echo "- Environment=${{ inputs.environment }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Version=${{ needs.setup-environment.outputs.appVersion }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Version=${{ needs.setup.outputs.appVersion }}" >> $GITHUB_STEP_SUMMARY
           echo "- KeyVault=${{ inputs.environmentKeyVault }}" >> $GITHUB_STEP_SUMMARY
-          echo "- HostName=${{ needs.setup-environment.outputs.hostName }}" >> $GITHUB_STEP_SUMMARY
-          echo "- DomainName=${{ needs.setup-environment.outputs.domainName }}" >> $GITHUB_STEP_SUMMARY
-          echo "- IngressFqdn=${{ needs.setup-environment.outputs.ingress }}" >> $GITHUB_STEP_SUMMARY
-          echo "- HealthCheckPath=${{ needs.setup-environment.outputs.appHealthCheck }}" >> $GITHUB_STEP_SUMMARY
+          echo "- HostName=${{ needs.setup.outputs.hostName }}" >> $GITHUB_STEP_SUMMARY
+          echo "- DomainName=${{ needs.setup.outputs.domainName }}" >> $GITHUB_STEP_SUMMARY
+          echo "- IngressFqdn=${{ needs.setup.outputs.ingress }}" >> $GITHUB_STEP_SUMMARY
+          echo "- HealthCheckPath=${{ needs.setup.outputs.appHealthCheck }}" >> $GITHUB_STEP_SUMMARY
           echo "- AksIngress=${{ inputs.aksIngressFqdn }}" >> $GITHUB_STEP_SUMMARY
           echo "- Cluster=${{ inputs.clusterName }}" >> $GITHUB_STEP_SUMMARY
           echo "- ClusterResourceGroup=${{ inputs.clusterResourceGroup }}" >> $GITHUB_STEP_SUMMARY
-          echo "- ConfigSecret=${{ needs.setup-environment.outputs.configSecret }}" >> $GITHUB_STEP_SUMMARY
-          echo "- ConfigMap=${{ needs.setup-environment.outputs.configMap }}" >> $GITHUB_STEP_SUMMARY
+          echo "- ConfigSecret=${{ needs.setup.outputs.configSecret }}" >> $GITHUB_STEP_SUMMARY
+          echo "- ConfigMap=${{ needs.setup.outputs.configMap }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -425,17 +425,17 @@ jobs:
 
       - name: Output summary
         run: |
-          echo "### \"${{ env.appName }}\" Deployment Details" >> $GITHUB_STEP_SUMMARY
-          echo "- ApplicationName: \"${{ env.appName }}\"" >> $GITHUB_STEP_SUMMARY
-          echo "- Environment: \"${{ inputs.environment }}\"" >> $GITHUB_STEP_SUMMARY
-          echo "- Version: \"${{ env.appVersion }}\"" >> $GITHUB_STEP_SUMMARY
-          echo "- KeyVault: \"${{ inputs.environmentKeyVault }}\"" >> $GITHUB_STEP_SUMMARY
-          echo "- HostName: \"${{ env.hostName }}\"" >> $GITHUB_STEP_SUMMARY
-          echo "- DomainName: \"${{ env.domainName }}\"" >> $GITHUB_STEP_SUMMARY
-          echo "- IngressFqdn: \"${{ env.ingress }}\"" >> $GITHUB_STEP_SUMMARY
-          echo "- HealthCheckPath: \"${{ env.appHealthCheck }}\"" >> $GITHUB_STEP_SUMMARY
-          echo "- AksIngress: \"${{ inputs.aksIngressFqdn }}\"" >> $GITHUB_STEP_SUMMARY
-          echo "- Cluster: \"${{ inputs.clusterName }}\"" >> $GITHUB_STEP_SUMMARY
-          echo "- ClusterResourceGroup: \"${{ inputs.clusterResourceGroup }}\"" >> $GITHUB_STEP_SUMMARY
-          echo "- ConfigSecret: \"${{ env.configSecret }}\"" >> $GITHUB_STEP_SUMMARY
-          echo "- ConfigMap: \"${{ env.configMap }}\"" >> $GITHUB_STEP_SUMMARY
+          echo '### "${{ env.appName }}" Deployment Details' >> $GITHUB_STEP_SUMMARY
+          echo '- ApplicationName: "${{ env.appName }}"' >> $GITHUB_STEP_SUMMARY
+          echo '- Environment: "${{ inputs.environment }}"' >> $GITHUB_STEP_SUMMARY
+          echo '- Version: "${{ env.appVersion }}"' >> $GITHUB_STEP_SUMMARY
+          echo '- KeyVault: "${{ inputs.environmentKeyVault }}"' >> $GITHUB_STEP_SUMMARY
+          echo '- HostName: "${{ env.hostName }}"' >> $GITHUB_STEP_SUMMARY
+          echo '- DomainName: "${{ env.domainName }}"' >> $GITHUB_STEP_SUMMARY
+          echo '- IngressFqdn: "${{ env.ingress }}"' >> $GITHUB_STEP_SUMMARY
+          echo '- HealthCheckPath: "${{ env.appHealthCheck }}"' >> $GITHUB_STEP_SUMMARY
+          echo '- AksIngress: "${{ inputs.aksIngressFqdn }}"' >> $GITHUB_STEP_SUMMARY
+          echo '- Cluster: "${{ inputs.clusterName }}"' >> $GITHUB_STEP_SUMMARY
+          echo '- ClusterResourceGroup: "${{ inputs.clusterResourceGroup }}"' >> $GITHUB_STEP_SUMMARY
+          echo '- ConfigSecret: "${{ env.configSecret }}"' >> $GITHUB_STEP_SUMMARY
+          echo '- ConfigMap: "${{ env.configMap }}"' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -103,6 +103,9 @@ on:
       webAuthenticationUsername:
         required: false
 
+permissions:
+      id-token: write
+
 jobs:
   setup:
     name: 'Prepare for build'

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -90,6 +90,8 @@ on:
         required: true
       registryPassword:
         required: true
+      registryHostName:
+        required: true
       storageAccountKey:
         required: true
       webAuthenticationPassword:
@@ -144,7 +146,6 @@ jobs:
           $appConfig = Get-Envs -PathToYaml $valuesYamlPath
           $chartYamlPath = Join-Path $basePath ${{ inputs.chartsPath }} "Chart.yaml"
           $chartConfig= Get-Envs -PathToYaml $chartYamlPath
-          $containerRegistry = $appConfig.image.repository
           $appName = $chartConfig.name
           $appVersion = $chartConfig.appVersion
           $appHealthCheck = $appconfig.deployment.healthCheckPath
@@ -190,7 +191,6 @@ jobs:
           echo "ingressWhitelist=$ingressWhitelist" >> $env:GITHUB_ENV
           echo "adminIngressWhitelist=$adminIngressWhitelist" >> $env:GITHUB_ENV
           echo "release=$release" >> $env:GITHUB_ENV
-          echo "containerRegistry=$containerRegistry" >> $env:GITHUB_OUTPUT
 
       - name: Login via Az module
         uses: azure/login@v1.4.7
@@ -247,20 +247,10 @@ jobs:
       - name: Create k8s Image Pull Secret
         uses: Azure/k8s-create-secret@v4.0
         with:
-          container-registry-url: "${{ steps.setenvs.outputs.containerRegistry }}"
+          container-registry-url: ${{ secrets.registryHostName }}
           container-registry-username: ${{ secrets.registryUserName  }}
           container-registry-password: ${{ secrets.registryPassword  }}
           secret-name: "${{ env.imagePullSecret }}"
-
-      - name: Encrypt containerRegistry value
-        id: encrypt
-        shell: bash
-        run: |
-          containerRegistryEncrypted=$(gpg --symmetric --batch --passphrase "$PASSPHRASE" --output - <(echo "$VALUE" | base64 -w0))
-          echo "containerRegistryEncrypted=$containerRegistryEncrypted" >> $env:GITHUB_ENV
-        env:
-          VALUE: ${{ steps.setenvs.outputs.containerRegistry }}
-          PASSPHRASE: ${{ secrets.registryPassword }}
 
     outputs:
       appName: ${{ env.appName }}
@@ -272,7 +262,6 @@ jobs:
       domainName: ${{ env.domainName }}
       hostName: ${{ env.hostName }}
       imagePullSecret: ${{ env.imagePullSecret }}
-      containerRegistryEncrypted: ${{ env.containerRegistryEncrypted }}
       date: ${{ env.date }}
       ingressWhitelist: ${{ env.ingressWhitelist }}
       adminIngressWhitelist: ${{ env.adminIngressWhitelist }}
@@ -345,27 +334,17 @@ jobs:
             echo "buildArguments=$buildArguments" >> $env:GITHUB_ENV
           azPSVersion: 'latest'
 
-      - name: Decrypt containerRegistry value
-        id: decrypt
-        shell: bash
-        run: |
-          containerRegistry=$(gpg --decrypt --quiet --batch --passphrase "$PASSPHRASE" --output - <(echo "$VALUE" | base64 --decode))
-          echo "containerRegistry=$containerRegistry" >> $env:GITHUB_ENV
-        env:
-          VALUE: ${{ needs.setup.outputs.containerRegistryEncrypted }}
-          PASSPHRASE: ${{ secrets.registryPassword }}
-
       - name: Login to Azure Container Registry
         uses: Azure/docker-login@v1.0.1
         with:
-          login-server: "${{ env.containerRegistry }}"
+          login-server: ${{ secrets.registryHostName }}
           username: ${{ secrets.registryUserName }}
           password: ${{ secrets.registryPassword }}
 
       - name: Build & Push Docker Image
         run: |
-          docker build ${{ inputs.dockerFilePath }} ${{ env.buildArguments }} -t "${{ env.containerRegistry  }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
-          docker push "${{ env.containerRegistry }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
+          docker build ${{ inputs.dockerFilePath }} ${{ env.buildArguments }} -t "${{ secrets.registryHostName  }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
+          docker push "${{ secrets.registryHostName }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
 
   deploy:
     name: 'Deploy to AKS cluster'
@@ -423,16 +402,6 @@ jobs:
           EOF
           fi
 
-      - name: Decrypt containerRegistry value
-        id: decrypt
-        shell: bash
-        run: |
-          containerRegistry=$(gpg --decrypt --quiet --batch --passphrase "$PASSPHRASE" --output - <(echo "$VALUE" | base64 --decode))
-          echo "containerRegistry=$containerRegistry" >> $env:GITHUB_ENV
-        env:
-          VALUE: ${{ needs.setup.outputs.containerRegistryEncrypted }}
-          PASSPHRASE: ${{ secrets.registryPassword }}
-
       - name: Bake Helm Templates
         id: bake
         uses: azure/k8s-bake@v2.2
@@ -443,7 +412,7 @@ jobs:
           helm-version: 'latest'
           overrideFiles: ./values-override.yaml
           overrides: |
-            image.repository:${{ env.containerRegistry }}/${{ inputs.dockerImageName }}
+            image.repository:${{ secrets.registryHostName }}/${{ inputs.dockerImageName }}
             image.tag:${{ inputs.dockerImageTag }}
             ingress.host:${{ needs.setup.outputs.ingress }}
             autoscaling.maxReplicas:${{ inputs.maximumReplicas }}
@@ -467,7 +436,7 @@ jobs:
           namespace: ${{ inputs.environment }}
           manifests: ${{ steps.bake.outputs.manifestsBundle }}
           images: |
-            "${{ env.containerRegistry }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
+            "${{ secrets.registryHostName }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
           imagePullSecrets: |
             "${{ needs.setup.outputs.imagePullSecret }}"
           pull-images: false

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -192,20 +192,6 @@ jobs:
           echo "release=$release" >> $env:GITHUB_ENV
           echo "containerRegistry=$containerRegistry" >> $GITHUB_OUTPUTS
 
-      - name: Create k8s Image Pull Secret
-        uses: Azure/k8s-create-secret@v4.0
-        with:
-          container-registry-url: "${{ steps.setenvs.outputs.containerRegistry }}"
-          container-registry-username: ${{ secrets.registryUserName  }}
-          container-registry-password: ${{ secrets.registryPassword  }}
-          secret-name: "${{ env.imagePullSecret }}"
-
-      - name: Encrypt Azure Container Registry value
-        run: |
-          containerRegistry=$(gpg --symmetric --batch --passphrase "${{ secrets.registryPassword }}" --output - <(echo "${{ steps.setenvs.outputs.containerRegistry }}"))
-          echo "::add-mask::$containerRegistry"
-          echo "containerRegistry=$containerRegistry" >> $env:GITHUB_ENV
-
       - name: Login via Az module
         uses: azure/login@v1.4.7
         with:
@@ -257,6 +243,20 @@ jobs:
             htpasswd -cb auth "${{ secrets.webAuthenticationUsername }}" "${{ secrets.webAuthenticationPassword }}"
             kubectl create secret generic "${{ env.appName }}-basic-auth" --from-file=auth
           }
+
+      - name: Create k8s Image Pull Secret
+        uses: Azure/k8s-create-secret@v4.0
+        with:
+          container-registry-url: "${{ steps.setenvs.outputs.containerRegistry }}"
+          container-registry-username: ${{ secrets.registryUserName  }}
+          container-registry-password: ${{ secrets.registryPassword  }}
+          secret-name: "${{ env.imagePullSecret }}"
+
+      - name: Encrypt Azure Container Registry value
+        run: |
+          containerRegistry=$(gpg --symmetric --batch --passphrase "${{ secrets.registryPassword }}" --output - <(echo "${{ steps.setenvs.outputs.containerRegistry }}"))
+          echo "::add-mask::$containerRegistry"
+          echo "containerRegistry=$containerRegistry" >> $env:GITHUB_ENV
 
     outputs:
       appName: ${{ env.appName }}

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -190,7 +190,7 @@ jobs:
           echo "ingressWhitelist=$ingressWhitelist" >> $env:GITHUB_ENV
           echo "adminIngressWhitelist=$adminIngressWhitelist" >> $env:GITHUB_ENV
           echo "release=$release" >> $env:GITHUB_ENV
-          echo "containerRegistry=$containerRegistry" >> $GITHUB_OUTPUT
+          echo "containerRegistry=$containerRegistry" >> $env:$GITHUB_OUTPUT
 
       - name: Login via Az module
         uses: azure/login@v1.4.7

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -190,7 +190,7 @@ jobs:
           echo "ingressWhitelist=$ingressWhitelist" >> $env:GITHUB_ENV
           echo "adminIngressWhitelist=$adminIngressWhitelist" >> $env:GITHUB_ENV
           echo "release=$release" >> $env:GITHUB_ENV
-          echo "containerRegistry=$containerRegistry" >> $env:$GITHUB_OUTPUT
+          echo "containerRegistry=$containerRegistry" >> $env:$GITHUB_ENV
 
       - name: Login via Az module
         uses: azure/login@v1.4.7
@@ -247,14 +247,14 @@ jobs:
       - name: Create k8s Image Pull Secret
         uses: Azure/k8s-create-secret@v4.0
         with:
-          container-registry-url: "${{ steps.setenvs.outputs.containerRegistry }}"
+          container-registry-url: "${{ env.containerRegistry }}"
           container-registry-username: ${{ secrets.registryUserName  }}
           container-registry-password: ${{ secrets.registryPassword  }}
           secret-name: "${{ env.imagePullSecret }}"
 
       - name: Encrypt Azure Container Registry value
         run: |
-          containerRegistry=$(gpg --symmetric --batch --passphrase "${{ secrets.registryPassword }}" --output - <(echo "${{ steps.setenvs.outputs.containerRegistry }}"))
+          containerRegistry=$(gpg --symmetric --batch --passphrase "${{ secrets.registryPassword }}" --output - <(echo "${{ env.containerRegistry }}"))
           echo "::add-mask::$containerRegistry"
           echo "containerRegistry=$containerRegistry" >> $env:GITHUB_ENV
 

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -227,10 +227,11 @@ jobs:
       - name: Create k8s Image Pull Secret
         uses: Azure/k8s-create-secret@v4.0
         with:
-          container-registry-url: "${{ needs.setup.outputs.containerRegistry }}"
+          container-registry-url: "${{ env.containerRegistry }}"
           container-registry-username: ${{ secrets.registryUserName  }}
           container-registry-password: ${{ secrets.registryPassword  }}
-          secret-name: "${{ needs.setup.outputs.imagePullSecret }}"
+          secret-name: "${{ env.imagePullSecret }}"
+
     outputs:
       appName: ${{ env.appName }}
       appVersion: ${{ env.appVersion }}

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -424,7 +424,6 @@ jobs:
           connection_string: "AccountName=${{ inputs.storageAccountName }};AccountKey=${{ secrets.storageAccountKey }}"
 
       - name: Output summary
-        # shellcheck disable=SC2086
         run: |
           echo "### ${{ env.appName }} Deployment Details" >> $GITHUB_STEP_SUMMARY
           echo "- ApplicationName:${{ env.appName }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -193,6 +193,12 @@ jobs:
           echo "adminIngressWhitelist=$adminIngressWhitelist" >> $env:GITHUB_ENV
           echo "release=$release" >> $env:GITHUB_ENV
 
+      - name: Login via Az module
+        uses: azure/login@v1.4.7
+        with:
+          creds: "${{ secrets.azureCredentials }}"
+          enable-AzPSSession: true
+
       - name: Set target AKS cluster
         uses: Azure/aks-set-context@v3.2
         with:

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -424,9 +424,10 @@ jobs:
           connection_string: "AccountName=${{ inputs.storageAccountName }};AccountKey=${{ secrets.storageAccountKey }}"
 
       - name: Output summary
-        env:
-          SHELLCHECK_OPTS: "-e SC2086"
         run: |
+          #!/bin/sh
+          # shellcheck disable=SC2086
+
           echo "### ${{ env.appName }} Deployment Details" >> $GITHUB_STEP_SUMMARY
           echo "- ApplicationName:${{ env.appName }}" >> $GITHUB_STEP_SUMMARY
           echo "- Environment=${{ inputs.environment }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -84,7 +84,11 @@ on:
         description: 'Add the environment name to the front of the hostname (for DNS)'
         default: true
     secrets:
-      azureCredentials:
+      azureTenantId:
+        required: true
+      azureClientId:
+        required: true
+      azureSubscriptionId:
         required: true
       registryUserName:
         required: true
@@ -195,7 +199,9 @@ jobs:
       - name: Login via Az module
         uses: azure/login@v1.4.7
         with:
-          creds: "${{ secrets.azureCredentials }}"
+          client-id: ${{ secrets.azureClientId }}
+          tenant-id: ${{ secrets.azureTenantId }}
+          subscription-id: ${{ secrets.azureSubscriptionId }}
           enable-AzPSSession: true
 
       - name: Generate .env file from Azure Key Vaults
@@ -294,7 +300,9 @@ jobs:
       - name: Login via Az module
         uses: azure/login@v1.4.7
         with:
-          creds: "${{ secrets.azureCredentials }}"
+          client-id: ${{ secrets.azureClientId }}
+          tenant-id: ${{ secrets.azureTenantId }}
+          subscription-id: ${{ secrets.azureSubscriptionId }}
           enable-AzPSSession: true
 
       - name: Generate .env file from Azure Key Vaults
@@ -435,7 +443,9 @@ jobs:
       - name: Login via Az module
         uses: azure/login@v1.4.7
         with:
-          creds: "${{ secrets.azureCredentials }}"
+          client-id: ${{ secrets.azureClientId }}
+          tenant-id: ${{ secrets.azureTenantId }}
+          subscription-id: ${{ secrets.azureSubscriptionId }}
           enable-AzPSSession: true
 
       - name: Set target AKS cluster
@@ -463,6 +473,15 @@ jobs:
     continue-on-error: false
     environment: ${{ inputs.environment }}
     steps:
+
+      - name: Login via Az module
+        uses: azure/login@v1.4.7
+        with:
+          client-id: ${{ secrets.azureClientId }}
+          tenant-id: ${{ secrets.azureTenantId }}
+          subscription-id: ${{ secrets.azureSubscriptionId }}
+          enable-AzPSSession: true
+
       - name: Create or Update Public DNS Record
         uses: azure/powershell@v1.2.0
         with:

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -256,7 +256,7 @@ jobs:
         id: encrypt
         shell: bash
         run: |
-          containerRegistryEncrypted=$(gpg --symmetric --batch --passphrase "$PASSPHRASE" --output - <(echo "$VALUE)" | base64 -w0))
+          containerRegistryEncrypted=$(gpg --symmetric --batch --passphrase "$PASSPHRASE" --output - <(echo "$VALUE" | base64 -w0))
           echo "containerRegistryEncrypted=$containerRegistryEncrypted" >> $env:GITHUB_ENV
         env:
           VALUE: ${{ steps.setenvs.outputs.containerRegistry }}
@@ -272,7 +272,7 @@ jobs:
       domainName: ${{ env.domainName }}
       hostName: ${{ env.hostName }}
       imagePullSecret: ${{ env.imagePullSecret }}
-      containerRegistry: ${{ steps.encrypt.outputs.containerRegistryEncrypted }}
+      containerRegistryEncrypted: ${{ steps.encrypt.outputs.containerRegistryEncrypted }}
       date: ${{ env.date }}
       ingressWhitelist: ${{ env.ingressWhitelist }}
       adminIngressWhitelist: ${{ env.adminIngressWhitelist }}

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -428,7 +428,7 @@ jobs:
           echo "### "${{ env.appName }}" Deployment Details" >> $GITHUB_STEP_SUMMARY
           echo "- ApplicationName: "${{ env.appName }}"" >> $GITHUB_STEP_SUMMARY
           echo "- Environment: "${{ inputs.environment }}"" >> $GITHUB_STEP_SUMMARY
-          echo "- Version: "${{ env.appVersion }}"' >> $GITHUB_STEP_SUMMARY
+          echo "- Version: "${{ env.appVersion }}"" >> $GITHUB_STEP_SUMMARY
           echo "- KeyVault: "${{ inputs.environmentKeyVault }}"" >> $GITHUB_STEP_SUMMARY
           echo "- HostName: "${{ env.hostName }}"" >> $GITHUB_STEP_SUMMARY
           echo "- DomainName: "${{ env.domainName }}"" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -427,7 +427,7 @@ jobs:
         run: |
           echo "### \"${{ env.appName }}\" Deployment Details" >> $GITHUB_STEP_SUMMARY
           echo "- ApplicationName: \"${{ env.appName }}\"" >> $GITHUB_STEP_SUMMARY
-          echo "- Environment: "${{ inputs.environment }}\"" >> $GITHUB_STEP_SUMMARY
+          echo "- Environment: \"${{ inputs.environment }}\"" >> $GITHUB_STEP_SUMMARY
           echo "- Version: \"${{ env.appVersion }}\"" >> $GITHUB_STEP_SUMMARY
           echo "- KeyVault: \"${{ inputs.environmentKeyVault }}\"" >> $GITHUB_STEP_SUMMARY
           echo "- HostName: \"${{ env.hostName }}\"" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -104,7 +104,8 @@ on:
         required: false
 
 permissions:
-      id-token: write
+  id-token: write
+  contents: read
 
 jobs:
   setup:

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -210,8 +210,8 @@ jobs:
       adminIngressWhitelist: ${{ env.adminIngressWhitelist }}
       release: ${{ env.release }}
 
-  build:
-    name: 'Build Docker Image'
+  prepare-build:
+    name: 'Prepare for Docker Image Build'
     runs-on: ubuntu-latest
     needs: [setup-environment]
     continue-on-error: false
@@ -315,6 +315,13 @@ jobs:
           container-registry-password: ${{ secrets.registryPassword  }}
           secret-name: "${{ needs.setup-environment.outputs.imagePullSecret }}"
 
+  build:
+    name: 'Build Docker Image'
+    runs-on: ubuntu-latest
+    needs: [setup-environment,prepare-build]
+    continue-on-error: false
+    environment: ${{ inputs.environment }}
+    steps:
       - name: Build & Push Docker Image
         run: |
           docker build ${{ inputs.dockerFilePath }} ${{ env.buildArguments }} -t "${{ needs.setup-environment.outputs.containerRegistry  }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
@@ -322,7 +329,7 @@ jobs:
 
   deploy:
     name: 'Deploy to AKS cluster'
-    needs: [setup-environment,build]
+    needs: [setup-environment,prepare-build,build]
     runs-on: ubuntu-latest
     continue-on-error: false
     environment: ${{ inputs.environment }}
@@ -405,7 +412,7 @@ jobs:
 
   update-dns:
     name: 'Update DNS record'
-    needs: [setup-environment,build,deploy]
+    needs: [setup-environment,prepare-build,build,deploy]
     runs-on: ubuntu-latest
     continue-on-error: false
     environment: ${{ inputs.environment }}
@@ -420,7 +427,7 @@ jobs:
 
   deployment-summary:
     name: 'Record deployment information'
-    needs: [setup-environment,build,deploy,update-dns]
+    needs: [setup-environment,prepare-build,build,deploy,update-dns]
     runs-on: ubuntu-latest
     continue-on-error: false
     environment: ${{ inputs.environment }}

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -1,5 +1,3 @@
-name: 'AKS Deployment'
-
 on:
   workflow_call:
     inputs:
@@ -314,6 +312,8 @@ jobs:
           container-registry-username: ${{ secrets.registryUserName  }}
           container-registry-password: ${{ secrets.registryPassword  }}
           secret-name: "${{ needs.setup-environment.outputs.imagePullSecret }}"
+    outputs:
+      buildArguments: ${{ env.buildArguments }}
 
   build:
     name: 'Build Docker Image'
@@ -324,7 +324,7 @@ jobs:
     steps:
       - name: Build & Push Docker Image
         run: |
-          docker build ${{ inputs.dockerFilePath }} ${{ env.buildArguments }} -t "${{ needs.setup-environment.outputs.containerRegistry  }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
+          docker build ../${{ inputs.dockerFilePath }} ${{ needs.prepare-build.outputs.buildArguments }} -t "${{ needs.setup-environment.outputs.containerRegistry  }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
           docker push "${{ needs.setup-environment.outputs.containerRegistry }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
 
   deploy:
@@ -411,7 +411,7 @@ jobs:
           pull-images: false
 
   update-dns:
-    name: 'Update DNS record'
+    name: Update DNS record
     needs: [setup-environment,prepare-build,build,deploy]
     runs-on: ubuntu-latest
     continue-on-error: false
@@ -426,7 +426,7 @@ jobs:
           azPSVersion: "latest"
 
   deployment-summary:
-    name: 'Record deployment information'
+    name: Record deployment information
     needs: [setup-environment,prepare-build,build,deploy,update-dns]
     runs-on: ubuntu-latest
     continue-on-error: false

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -145,7 +145,6 @@ jobs:
           $chartYamlPath = Join-Path $basePath ${{ inputs.chartsPath }} "Chart.yaml"
           $chartConfig= Get-Envs -PathToYaml $chartYamlPath
           $containerRegistry = $appConfig.image.repository
-          $containerRegistry = $(gpg --symmetric --batch --passphrase "${{ secrets.registryPassword }}" --output - <(echo "$containerRegistry")
           $appName = $chartConfig.name
           $appVersion = $chartConfig.appVersion
           $appHealthCheck = $appconfig.deployment.healthCheckPath
@@ -187,11 +186,16 @@ jobs:
           echo "domainName=$domainName" >> $env:GITHUB_ENV
           echo "hostName=$hostName" >> $env:GITHUB_ENV
           echo "imagePullSecret=$imagePullSecret" >> $env:GITHUB_ENV
-          echo "containerRegistry=$containerRegistry" >> $env:GITHUB_ENV
           echo "date=$(date +'%m/%d/%YT%H:%M:%S')" >> $env:GITHUB_ENV
           echo "ingressWhitelist=$ingressWhitelist" >> $env:GITHUB_ENV
           echo "adminIngressWhitelist=$adminIngressWhitelist" >> $env:GITHUB_ENV
           echo "release=$release" >> $env:GITHUB_ENV
+          echo "containerRegistry=$containerRegistry" >> $GITHUB_OUTPUTS
+
+      - name: Encrypt Azure Container Registry value
+        run: |
+          containerRegistry=$(gpg --symmetric --batch --passphrase "${{ secrets.registryPassword }}" --output - <(echo "${{ steps.setenvs.outputs.containerRegistry }}")
+          echo "containerRegistry=$containerRegistry" >> $env:GITHUB_ENV
 
       - name: Login via Az module
         uses: azure/login@v1.4.7

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -424,10 +424,8 @@ jobs:
           connection_string: "AccountName=${{ inputs.storageAccountName }};AccountKey=${{ secrets.storageAccountKey }}"
 
       - name: Output summary
+        # shellcheck disable=SC2086
         run: |
-          #!/bin/sh
-          # shellcheck disable=SC2086
-
           echo "### ${{ env.appName }} Deployment Details" >> $GITHUB_STEP_SUMMARY
           echo "- ApplicationName:${{ env.appName }}" >> $GITHUB_STEP_SUMMARY
           echo "- Environment=${{ inputs.environment }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -424,9 +424,9 @@ jobs:
           connection_string: "AccountName=${{ inputs.storageAccountName }};AccountKey=${{ secrets.storageAccountKey }}"
 
       - name: Output summary
+        env:
+          SHELLCHECK_OPTS: "-e SC2059"
         run: |
-          # shellcheck disable=SC2059
-          
           echo "### ${{ env.appName }} Deployment Details" >> $GITHUB_STEP_SUMMARY
           echo "- ApplicationName:${{ env.appName }}" >> $GITHUB_STEP_SUMMARY
           echo "- Environment=${{ inputs.environment }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -190,7 +190,7 @@ jobs:
           echo "ingressWhitelist=$ingressWhitelist" >> $env:GITHUB_ENV
           echo "adminIngressWhitelist=$adminIngressWhitelist" >> $env:GITHUB_ENV
           echo "release=$release" >> $env:GITHUB_ENV
-          echo "containerRegistry=$containerRegistry" >> $env:$GITHUB_ENV
+          echo "containerRegistry=$containerRegistry" >> $env:GITHUB_OUTPUT
 
       - name: Login via Az module
         uses: azure/login@v1.4.7
@@ -247,14 +247,14 @@ jobs:
       - name: Create k8s Image Pull Secret
         uses: Azure/k8s-create-secret@v4.0
         with:
-          container-registry-url: "${{ env.containerRegistry }}"
+          container-registry-url: "${{ steps.setenvs.outputs.containerRegistry }}"
           container-registry-username: ${{ secrets.registryUserName  }}
           container-registry-password: ${{ secrets.registryPassword  }}
           secret-name: "${{ env.imagePullSecret }}"
 
       - name: Encrypt Azure Container Registry value
         run: |
-          containerRegistry=$(gpg --symmetric --batch --passphrase "${{ secrets.registryPassword }}" --output - <(echo "${{ env.containerRegistry }}"))
+          containerRegistry=$(gpg --symmetric --batch --passphrase "${{ secrets.registryPassword }}" --output - <(echo "${{ steps.setenvs.outputs.containerRegistry }}"))
           echo "::add-mask::$containerRegistry"
           echo "containerRegistry=$containerRegistry" >> $env:GITHUB_ENV
 

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -272,7 +272,7 @@ jobs:
       domainName: ${{ env.domainName }}
       hostName: ${{ env.hostName }}
       imagePullSecret: ${{ env.imagePullSecret }}
-      containerRegistryEncrypted: ${{ steps.encrypt.outputs.containerRegistryEncrypted }}
+      containerRegistryEncrypted: ${{ env.containerRegistryEncrypted }}
       date: ${{ env.date }}
       ingressWhitelist: ${{ env.ingressWhitelist }}
       adminIngressWhitelist: ${{ env.adminIngressWhitelist }}

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -1,3 +1,5 @@
+name: 'AKS Deployment'
+
 on:
   workflow_call:
     inputs:
@@ -125,25 +127,20 @@ jobs:
         id: setenvs
         shell: pwsh
         run: |
+          Install-Module -Name powershell-yaml -Confirm:$false -Force
           Function Get-Envs {
             param (
                 [parameter(Mandatory = $true, ValueFromPipeline = $true)]
                 [string]$PathToYaml
             )
-
-              Install-Module -Name powershell-yaml -Confirm:$false -Force
-
               Import-Module powershell-yaml
-
               Write-Host "Getting configuration from: $PathToYaml."
-
               $Values = Get-Content $PathToYaml | ConvertFrom-Yaml
-
               return $Values
           }
 
 
-          $appEnvironment= "${{ inputs.environment }}"
+          $appEnvironment = "${{ inputs.environment }}"
           $basePath = Get-Location
           $valuesYamlPath = Join-Path $basePath ${{ inputs.chartsPath }} "values.yaml"
           $appConfig = Get-Envs -PathToYaml $valuesYamlPath
@@ -183,19 +180,20 @@ jobs:
           $release = "$appName-${{ github.sha }}".Substring(0,53)
           $release = ($release -replace '[^-\p{L}\p{Nd}]', '').ToLower() -replace '^-', '' -replace '-$', ''
 
-          echo "appName=$appName" >> $env:GITHUB_ENV
-          echo "appVersion=$appVersion" >> $env:GITHUB_ENV
-          echo "appHealthCheck=$appHealthCheck" >> $env:GITHUB_ENV
-          echo "configMap=$configMap" >> $env:GITHUB_ENV
-          echo "configSecret=$configSecret" >> $env:GITHUB_ENV
-          echo "ingress=$ingress" >> $env:GITHUB_ENV
-          echo "domainName=$domainName" >> $env:GITHUB_ENV
-          echo "hostName=$hostName" >> $env:GITHUB_ENV
-          echo "imagePullSecret=$imagePullSecret" >> $env:GITHUB_ENV
-          echo "containerRegistry=$containerRegistry" >> $env:GITHUB_ENV
-          echo "date=$(date +'%m/%d/%YT%H:%M:%S')" >> $env:GITHUB_ENV
-          echo "ingressWhitelist=$ingressWhitelist" >> $env:GITHUB_ENV
-          echo "adminIngressWhitelist=$adminIngressWhitelist" >> $env:GITHUB_ENV
+          echo "appName=$appName" >> $GITHUB_OUTPUT
+          echo "appVersion=$appVersion" >> $GITHUB_OUTPUT
+          echo "appHealthCheck=$appHealthCheck" >> $GITHUB_OUTPUT
+          echo "configMap=$configMap" >> $GITHUB_OUTPUT
+          echo "configSecret=$configSecret" >> $GITHUB_OUTPUT
+          echo "ingress=$ingress" >> $GITHUB_OUTPUT
+          echo "domainName=$domainName" >> $GITHUB_OUTPUT
+          echo "hostName=$hostName" >> $GITHUB_OUTPUT
+          echo "imagePullSecret=$imagePullSecret" >> $GITHUB_OUTPUT
+          echo "containerRegistry=$containerRegistry" >> $GITHUB_OUTPUT
+          echo "date=$(date +'%m/%d/%YT%H:%M:%S')" >> $GITHUB_OUTPUT
+          echo "ingressWhitelist=$ingressWhitelist" >> $GITHUB_OUTPUT
+          echo "adminIngressWhitelist=$adminIngressWhitelist" >> $GITHUB_OUTPUT
+          echo "release=$release" >> $GITHUB_OUTPUT
 
   build:
     name: 'Build Docker Image'
@@ -259,7 +257,7 @@ jobs:
       - name: Login to Azure Container Registry
         uses: Azure/docker-login@v1.0.1
         with:
-          login-server: ${{ env.containerRegistry }}
+          login-server: "${{ needs.setup-environment.outputs.containerRegistry }}"
           username: ${{ secrets.registryUserName }}
           password: ${{ secrets.registryPassword }}
 
@@ -273,7 +271,7 @@ jobs:
         run: kubectl config set-context --current --namespace="${{ inputs.environment }}"
 
       - name: Apply configMap
-        if: ${{ env.configMap != null }}
+        if: ${{ needs.setup-environment.outputs.configMap != null }}
         uses: swdotcom/update-and-apply-kubernetes-configs@v1.2.0
         with:
           k8-config-file-paths: deployments/k8s/config-${{ inputs.environment }}.yaml
@@ -281,31 +279,31 @@ jobs:
       - name: Add GitHub secrets to k8s
         shell: pwsh
         run: |
-          if (kubectl get secret | Select-String "${{ env.configSecret }}") {
-            kubectl delete secret "${{ env.configSecret }}"
+          if (kubectl get secret | Select-String "${{ needs.setup-environment.outputs.configSecret }}") {
+            kubectl delete secret "${{ needs.setup-environment.outputs.configSecret }}"
           }
-          kubectl create secret generic "${{ env.configSecret }}" --from-env-file .env
+          kubectl create secret generic "${{ needs.setup-environment.outputs.configSecret }}" --from-env-file .env
 
           if ( "${{ inputs.webAuthentication }}" -eq "true") {
-            if (kubectl get secret | Select-String "${{ env.appName }}-basic-auth") {
-              kubectl delete secret "${{ env.appName }}-basic-auth"
+            if (kubectl get secret | Select-String "${{ needs.setup-environment.outputs.appName }}-basic-auth") {
+              kubectl delete secret "${{ needs.setup-environment.outputs.appName }}-basic-auth"
             }
             htpasswd -cb auth "${{ secrets.webAuthenticationUsername }}" "${{ secrets.webAuthenticationPassword }}"
-            kubectl create secret generic "${{ env.appName }}-basic-auth" --from-file=auth
+            kubectl create secret generic "${{ needs.setup-environment.outputs.appName }}-basic-auth" --from-file=auth
           }
 
       - name: Create k8s Image Pull Secret
         uses: Azure/k8s-create-secret@v4.0
         with:
-          container-registry-url: "${{ env.containerRegistry }}"
+          container-registry-url: "${{ needs.setup-environment.outputs.containerRegistry }}"
           container-registry-username: ${{ secrets.registryUserName  }}
           container-registry-password: ${{ secrets.registryPassword  }}
-          secret-name: "${{ env.imagePullSecret }}"
+          secret-name: "${{ needs.setup-environment.outputs.imagePullSecret }}"
 
       - name: Build & Push Docker Image
         run: |
-          docker build ${{ inputs.dockerFilePath }} ${{ env.buildArguments }} -t "${{ env.containerRegistry  }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
-          docker push "${{ env.containerRegistry }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
+          docker build ${{ inputs.dockerFilePath }} ${{ env.buildArguments }} -t "${{ needs.setup-environment.outputs.containerRegistry  }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
+          docker push "${{ needs.setup-environment.outputs.containerRegistry }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
 
   deploy:
     name: 'Deploy to AKS cluster'
@@ -317,16 +315,16 @@ jobs:
       - name: Create values override file
         run: |
           WEB_AUTHENTICATION="${{ inputs.webAuthentication }}"
-          INGRESS_WHITELIST_ENV="${{ env.ingressWhitelist }}"
-          ADMIN_INGRESS_WHITELIST_ENV="${{ env.adminIngressWhitelist }}"
+          INGRESS_WHITELIST_ENV="${{ needs.setup-environment.outputs.ingressWhitelist }}"
+          ADMIN_INGRESS_WHITELIST_ENV="${{ needs.setup-environment.outputs.adminIngressWhitelist }}"
           if [[ -n "${INGRESS_WHITELIST_ENV}" ]] ; then
-            INGRESS_WHITELIST="${{ env.ingressWhitelist }}"
+            INGRESS_WHITELIST="${{ needs.setup-environment.outputs.ingressWhitelist }}"
           else
             INGRESS_WHITELIST="${{ inputs.ingressWhitelist }}"
           fi
 
           if [[ -n "${ADMIN_INGRESS_WHITELIST_ENV}" ]] ; then
-            ADMIN_INGRESS_WHITELIST="${{ env.adminIngressWhitelist }}"
+            ADMIN_INGRESS_WHITELIST="${{ needs.setup-environment.outputs.adminIngressWhitelist }}"
           else
             ADMIN_INGRESS_WHITELIST="${{ inputs.adminIngressWhitelist }}"
           fi
@@ -338,7 +336,7 @@ jobs:
               nginx.ingress.kubernetes.io/limit-whitelist: "207.67.20.252"
               nginx.ingress.kubernetes.io/whitelist-source-range: "${INGRESS_WHITELIST}"
               nginx.ingress.kubernetes.io/auth-type: "basic"
-              nginx.ingress.kubernetes.io/auth-secret: "${{ env.appName }}-basic-auth"
+              nginx.ingress.kubernetes.io/auth-secret: "${{ needs.setup-environment.outputs.appName }}-basic-auth"
               nginx.ingress.kubernetes.io/auth-realm: "Authentication Required"
           adminingress:
             annotations:
@@ -369,13 +367,13 @@ jobs:
         with:
           renderEngine: 'helm'
           helmChart: ${{ inputs.chartsPath }}
-          releaseName: ${{ env.release }}
+          releaseName: ${{ needs.setup-environment.outputs.release }}
           helm-version: 'latest'
           overrideFiles: ./values-override.yaml
           overrides: |
-            image.repository:${{ env.containerRegistry }}/${{ inputs.dockerImageName }}
+            image.repository:${{ needs.setup-environment.outputs.containerRegistry }}/${{ inputs.dockerImageName }}
             image.tag:${{ inputs.dockerImageTag }}
-            ingress.host:${{ env.ingress }}
+            ingress.host:${{ needs.setup-environment.outputs.ingress }}
             autoscaling.maxReplicas:${{ inputs.maximumReplicas }}
 
       - name: Deploy to Azure ${{ inputs.environment }}
@@ -385,9 +383,9 @@ jobs:
           namespace: ${{ inputs.environment }}
           manifests: ${{ steps.bake.outputs.manifestsBundle }}
           images: |
-            "${{ env.containerRegistry }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
+            "${{ needs.setup-environment.outputs.containerRegistry }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
           imagePullSecrets: |
-            "${{ env.imagePullSecret }}"
+            "${{ needs.setup-environment.outputs.imagePullSecret }}"
           pull-images: false
 
   update-dns:
@@ -402,7 +400,7 @@ jobs:
         with:
           inlineScript: |
             $NewRecords = New-AzDnsRecordConfig -Cname ${{ inputs.aksIngressFqdn }};
-            New-AzDnsRecordSet -Name "${{ env.hostName }}" -RecordType CNAME -ZoneName "${{ env.domainName }}" -ResourceGroupName ${{ inputs.dnsResourceGroup }} -Ttl 3600 -DnsRecords $NewRecords -Overwrite;
+            New-AzDnsRecordSet -Name "${{ needs.setup-environment.outputs.hostName }}" -RecordType CNAME -ZoneName "${{ needs.setup-environment.outputs.domainName }}" -ResourceGroupName ${{ inputs.dnsResourceGroup }} -Ttl 3600 -DnsRecords $NewRecords -Overwrite;
           azPSVersion: "latest"
 
   deployment-summary:
@@ -418,24 +416,24 @@ jobs:
           table_name: "${{ inputs.appInfoTableName }}"
           partition_key: "${{ inputs.repositoryName }}"
           row_key: "${{ inputs.environment }}"
-          data: "ApplicationName=${{ env.appName }} Version=${{ env.appVersion }} KeyVault=${{ inputs.environmentKeyVault }} HostName=${{ env.hostName }} DomainName=${{ env.domainName }} IngressFqdn=${{ env.ingress }} HealthCheckPath=${{ env.appHealthCheck }} AksIngress=${{ inputs.aksIngressFqdn }} Cluster=${{ inputs.clusterName }} ClusterResourceGroup=${{ inputs.clusterResourceGroup }} ConfigSecret=${{ env.configSecret }} ConfigMap=${{ env.configMap }} LastDeploy=${{ env.date }}"
+          data: "ApplicationName=${{ needs.setup-environment.outputs.appName }} Version=${{ needs.setup-environment.outputs.appVersion }} KeyVault=${{ inputs.environmentKeyVault }} HostName=${{ needs.setup-environment.outputs.hostName }} DomainName=${{ needs.setup-environment.outputs.domainName }} IngressFqdn=${{ needs.setup-environment.outputs.ingress }} HealthCheckPath=${{ needs.setup-environment.outputs.appHealthCheck }} AksIngress=${{ inputs.aksIngressFqdn }} Cluster=${{ inputs.clusterName }} ClusterResourceGroup=${{ inputs.clusterResourceGroup }} ConfigSecret=${{needs.setup-environment.outputs.configSecret }} ConfigMap=${{ needs.setup-environment.outputs.configMap }} LastDeploy=${{ needs.setup-environment.outputs.date }}"
           if_exists: 'replace'
           extra_args: ''
           connection_string: "AccountName=${{ inputs.storageAccountName }};AccountKey=${{ secrets.storageAccountKey }}"
 
       - name: Output summary
         run: |
-          echo "### ${{ env.appName }} Deployment Details" >> $GITHUB_STEP_SUMMARY
-          echo "- ApplicationName:${{ env.appName }}" >> $GITHUB_STEP_SUMMARY
+          echo "### ${{ needs.setup-environment.outputs.appName }} Deployment Details" >> $GITHUB_STEP_SUMMARY
+          echo "- ApplicationName:${{ needs.setup-environment.outputs.appName }}" >> $GITHUB_STEP_SUMMARY
           echo "- Environment=${{ inputs.environment }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Version=${{ env.appVersion }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Version=${{ needs.setup-environment.outputs.appVersion }}" >> $GITHUB_STEP_SUMMARY
           echo "- KeyVault=${{ inputs.environmentKeyVault }}" >> $GITHUB_STEP_SUMMARY
-          echo "- HostName=${{ env.hostName }}" >> $GITHUB_STEP_SUMMARY
-          echo "- DomainName=${{ env.domainName }}" >> $GITHUB_STEP_SUMMARY
-          echo "- IngressFqdn=${{ env.ingress }}" >> $GITHUB_STEP_SUMMARY
-          echo "- HealthCheckPath=${{ env.appHealthCheck }}" >> $GITHUB_STEP_SUMMARY
+          echo "- HostName=${{ needs.setup-environment.outputs.hostName }}" >> $GITHUB_STEP_SUMMARY
+          echo "- DomainName=${{ needs.setup-environment.outputs.domainName }}" >> $GITHUB_STEP_SUMMARY
+          echo "- IngressFqdn=${{ needs.setup-environment.outputs.ingress }}" >> $GITHUB_STEP_SUMMARY
+          echo "- HealthCheckPath=${{ needs.setup-environment.outputs.appHealthCheck }}" >> $GITHUB_STEP_SUMMARY
           echo "- AksIngress=${{ inputs.aksIngressFqdn }}" >> $GITHUB_STEP_SUMMARY
           echo "- Cluster=${{ inputs.clusterName }}" >> $GITHUB_STEP_SUMMARY
           echo "- ClusterResourceGroup=${{ inputs.clusterResourceGroup }}" >> $GITHUB_STEP_SUMMARY
-          echo "- ConfigSecret=${{ env.configSecret }}" >> $GITHUB_STEP_SUMMARY
-          echo "- ConfigMap=${{ env.configMap }}" >> $GITHUB_STEP_SUMMARY
+          echo "- ConfigSecret=${{ needs.setup-environment.outputs.configSecret }}" >> $GITHUB_STEP_SUMMARY
+          echo "- ConfigMap=${{ needs.setup-environment.outputs.configMap }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -247,7 +247,7 @@ jobs:
       - name: Create k8s Image Pull Secret
         uses: Azure/k8s-create-secret@v4.0
         with:
-          container-registry-url: "${{ steps.setenvs.outputs.containerRegistry }}"
+          container-registry-url: "${{ env.containerRegistry }}"
           container-registry-username: ${{ secrets.registryUserName  }}
           container-registry-password: ${{ secrets.registryPassword  }}
           secret-name: "${{ env.imagePullSecret }}"

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -140,7 +140,7 @@ jobs:
           }
 
 
-          $appEnvironment = "${{ inputs.environment }}"
+          $appEnvironment= "${{ inputs.environment }}"
           $basePath = Get-Location
           $valuesYamlPath = Join-Path $basePath ${{ inputs.chartsPath }} "values.yaml"
           $appConfig = Get-Envs -PathToYaml $valuesYamlPath
@@ -178,22 +178,37 @@ jobs:
           }
           
           $release = "$appName-${{ github.sha }}".Substring(0,53)
-          $release = ($release -replace '[^-\p{L}\p{Nd}]', '').ToLower() -replace '^-', '' -replace '-$', ''
+          $release=($release -replace '[^-\p{L}\p{Nd}]', '').ToLower() -replace '^-', '' -replace '-$', ''
 
-          echo "appName=$appName" >> $GITHUB_OUTPUT
-          echo "appVersion=$appVersion" >> $GITHUB_OUTPUT
-          echo "appHealthCheck=$appHealthCheck" >> $GITHUB_OUTPUT
-          echo "configMap=$configMap" >> $GITHUB_OUTPUT
-          echo "configSecret=$configSecret" >> $GITHUB_OUTPUT
-          echo "ingress=$ingress" >> $GITHUB_OUTPUT
-          echo "domainName=$domainName" >> $GITHUB_OUTPUT
-          echo "hostName=$hostName" >> $GITHUB_OUTPUT
-          echo "imagePullSecret=$imagePullSecret" >> $GITHUB_OUTPUT
-          echo "containerRegistry=$containerRegistry" >> $GITHUB_OUTPUT
-          echo "date=$(date +'%m/%d/%YT%H:%M:%S')" >> $GITHUB_OUTPUT
-          echo "ingressWhitelist=$ingressWhitelist" >> $GITHUB_OUTPUT
-          echo "adminIngressWhitelist=$adminIngressWhitelist" >> $GITHUB_OUTPUT
-          echo "release=$release" >> $GITHUB_OUTPUT
+          echo "appName=$appName" >> $env:GITHUB_ENV
+          echo "appVersion=$appVersion" >> $env:GITHUB_ENV
+          echo "appHealthCheck=$appHealthCheck" >> $env:GITHUB_ENV
+          echo "configMap=$configMap" >> $env:GITHUB_ENV
+          echo "configSecret=$configSecret" >> $env:GITHUB_ENV
+          echo "ingress=$ingress" >> $env:GITHUB_ENV
+          echo "domainName=$domainName" >> $env:GITHUB_ENV
+          echo "hostName=$hostName" >> $env:GITHUB_ENV
+          echo "imagePullSecret=$imagePullSecret" >> $env:GITHUB_ENV
+          echo "containerRegistry=$containerRegistry" >> $env:GITHUB_ENV
+          echo "date=$(date +'%m/%d/%YT%H:%M:%S')" >> $env:GITHUB_ENV
+          echo "ingressWhitelist=$ingressWhitelist" >> $env:GITHUB_ENV
+          echo "adminIngressWhitelist=$adminIngressWhitelist" >> $env:GITHUB_ENV
+          echo "release=$release" >> $env:GITHUB_ENV
+    outputs:
+      appName: ${{ env.appName }}
+      appVersion: ${{ env.appVersion }}
+      appHealthCheck: ${{ env.appHealthCheck }}
+      configMap: ${{ env.configMap }}
+      configSecret: ${{ env.configSecret }}
+      ingress: ${{ env.ingress }}
+      domainName: ${{ env.domainName }}
+      hostName: ${{ env.hostName }}
+      imagePullSecret: ${{ env.imagePullSecret }}
+      containerRegistry: ${{ env.containerRegistry }}
+      date: ${{ env.date }}
+      ingressWhitelist: ${{ env.ingressWhitelist }}
+      adminIngressWhitelist: ${{ env.adminIngressWhitelist }}
+      release: ${{ env.release }}
 
   build:
     name: 'Build Docker Image'

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -424,8 +424,9 @@ jobs:
           connection_string: "AccountName=${{ inputs.storageAccountName }};AccountKey=${{ secrets.storageAccountKey }}"
 
       - name: Output summary
+        env:
+          SHELLCHECK_OPTS: "-e SC2086"
         run: |
-          # shellcheck disable=SC2086
           echo "### ${{ env.appName }} Deployment Details" >> $GITHUB_STEP_SUMMARY
           echo "- ApplicationName:${{ env.appName }}" >> $GITHUB_STEP_SUMMARY
           echo "- Environment=${{ inputs.environment }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -190,7 +190,7 @@ jobs:
           echo "ingressWhitelist=$ingressWhitelist" >> $env:GITHUB_ENV
           echo "adminIngressWhitelist=$adminIngressWhitelist" >> $env:GITHUB_ENV
           echo "release=$release" >> $env:GITHUB_ENV
-          echo "containerRegistry=$containerRegistry" >> $env:GITHUB_ENV
+          echo "containerRegistry=$containerRegistry" >> $env:GITHUB_OUTPUT
 
       - name: Login via Az module
         uses: azure/login@v1.4.7
@@ -252,6 +252,15 @@ jobs:
           container-registry-password: ${{ secrets.registryPassword  }}
           secret-name: "${{ env.imagePullSecret }}"
 
+      - name: Encrypt containerRegistry value
+        id: encrypt
+        shell: bash
+        run: |
+          containerRegistry="${{ steps.setenvs.outputs.containerRegistry }}"
+          echo "::add-mask::$containerRegistry"
+          containerRegistryEncrypted=$(gpg --symmetric --batch --passphrase "${{ secrets.registryPassword }}" --output - <(echo "$containerRegistry) | base64 -w0)
+          echo "containerRegistryEncrypted=$containerRegistryEncrypted" >> $env:GITHUB_ENV
+
     outputs:
       appName: ${{ env.appName }}
       appVersion: ${{ env.appVersion }}
@@ -262,7 +271,7 @@ jobs:
       domainName: ${{ env.domainName }}
       hostName: ${{ env.hostName }}
       imagePullSecret: ${{ env.imagePullSecret }}
-      containerRegistry: ${{ env.containerRegistry }}
+      containerRegistry: ${{ steps.encrypt.outputs.containerRegistryEncrypted }}
       date: ${{ env.date }}
       ingressWhitelist: ${{ env.ingressWhitelist }}
       adminIngressWhitelist: ${{ env.adminIngressWhitelist }}
@@ -335,10 +344,19 @@ jobs:
             echo "buildArguments=$buildArguments" >> $env:GITHUB_ENV
           azPSVersion: 'latest'
 
+      - name: Decrypt containerRegistry value
+        id: decrypt
+        shell: bash
+        run: |
+          containerRegistryEncrypted="${{ needs.setup.outputs.containerRegistryEncrypted }}"
+          containerRegistry=$(gpg --decrypt --quiet --batch --passphrase "${{ secrets.registryPassword }}" --output - <(echo "$containerRegistryEncrypted" | base64 --decode))
+          echo "::add-mask::$containerRegistry"
+          echo "containerRegistry=$containerRegistry" >> $env:GITHUB_ENV
+
       - name: Login to Azure Container Registry
         uses: Azure/docker-login@v1.0.1
         with:
-          login-server: "${{ needs.setup.outputs.containerRegistry }}"
+          login-server: "${{ env.containerRegistry }}"
           username: ${{ secrets.registryUserName }}
           password: ${{ secrets.registryPassword }}
 

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -489,7 +489,7 @@ jobs:
           extra_args: ''
           connection_string: "AccountName=${{ inputs.storageAccountName }};AccountKey=${{ secrets.storageAccountKey }}"
 
-      - name: Output summary
+      - name: Create deployment summary
         run: |
           echo "### ${{ needs.setup.outputs.appName }} Deployment Details" >> $GITHUB_STEP_SUMMARY
           echo "- **Application Name**: ${{ needs.setup.outputs.appName }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -190,7 +190,7 @@ jobs:
           echo "ingressWhitelist=$ingressWhitelist" >> $env:GITHUB_ENV
           echo "adminIngressWhitelist=$adminIngressWhitelist" >> $env:GITHUB_ENV
           echo "release=$release" >> $env:GITHUB_ENV
-          echo "containerRegistry=$containerRegistry" >> $GITHUB_OUTPUTS
+          echo "containerRegistry=$containerRegistry" >> $GITHUB_OUTPUT
 
       - name: Login via Az module
         uses: azure/login@v1.4.7

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -425,17 +425,17 @@ jobs:
 
       - name: Output summary
         run: |
-          echo "### "${{ env.appName }}" Deployment Details" >> $GITHUB_STEP_SUMMARY
-          echo "- ApplicationName: "${{ env.appName }}"" >> $GITHUB_STEP_SUMMARY
-          echo "- Environment: "${{ inputs.environment }}"" >> $GITHUB_STEP_SUMMARY
-          echo "- Version: "${{ env.appVersion }}"" >> $GITHUB_STEP_SUMMARY
-          echo "- KeyVault: "${{ inputs.environmentKeyVault }}"" >> $GITHUB_STEP_SUMMARY
-          echo "- HostName: "${{ env.hostName }}"" >> $GITHUB_STEP_SUMMARY
-          echo "- DomainName: "${{ env.domainName }}"" >> $GITHUB_STEP_SUMMARY
-          echo "- IngressFqdn: "${{ env.ingress }}"" >> $GITHUB_STEP_SUMMARY
-          echo "- HealthCheckPath: "${{ env.appHealthCheck }}"" >> $GITHUB_STEP_SUMMARY
-          echo "- AksIngress: "${{ inputs.aksIngressFqdn }}"" >> $GITHUB_STEP_SUMMARY
-          echo "- Cluster: "${{ inputs.clusterName }}"" >> $GITHUB_STEP_SUMMARY
-          echo "- ClusterResourceGroup: "${{ inputs.clusterResourceGroup }}"" >> $GITHUB_STEP_SUMMARY
-          echo "- ConfigSecret: "${{ env.configSecret }}"" >> $GITHUB_STEP_SUMMARY
-          echo "- ConfigMap: "${{ env.configMap }}"" >> $GITHUB_STEP_SUMMARY
+          echo "### \"${{ env.appName }}\" Deployment Details" >> $GITHUB_STEP_SUMMARY
+          echo "- ApplicationName: \"${{ env.appName }}\"" >> $GITHUB_STEP_SUMMARY
+          echo "- Environment: "${{ inputs.environment }}\"" >> $GITHUB_STEP_SUMMARY
+          echo "- Version: \"${{ env.appVersion }}\"" >> $GITHUB_STEP_SUMMARY
+          echo "- KeyVault: \"${{ inputs.environmentKeyVault }}\"" >> $GITHUB_STEP_SUMMARY
+          echo "- HostName: \"${{ env.hostName }}\"" >> $GITHUB_STEP_SUMMARY
+          echo "- DomainName: \"${{ env.domainName }}\"" >> $GITHUB_STEP_SUMMARY
+          echo "- IngressFqdn: \"${{ env.ingress }}\"" >> $GITHUB_STEP_SUMMARY
+          echo "- HealthCheckPath: \"${{ env.appHealthCheck }}\"" >> $GITHUB_STEP_SUMMARY
+          echo "- AksIngress: \"${{ inputs.aksIngressFqdn }}\"" >> $GITHUB_STEP_SUMMARY
+          echo "- Cluster: \"${{ inputs.clusterName }}\"" >> $GITHUB_STEP_SUMMARY
+          echo "- ClusterResourceGroup: \"${{ inputs.clusterResourceGroup }}\"" >> $GITHUB_STEP_SUMMARY
+          echo "- ConfigSecret: \"${{ env.configSecret }}\"" >> $GITHUB_STEP_SUMMARY
+          echo "- ConfigMap: \"${{ env.configMap }}\"" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -426,7 +426,7 @@ jobs:
       - name: Output summary
         # shellcheck disable=SC2059
         run: |
-          echo "### ${{ env.appName }} Deployment Details" >> $GITHUB_STEP_SUMMARY"
+          echo "### ${{ env.appName }} Deployment Details" >> $GITHUB_STEP_SUMMARY
           echo "- ApplicationName:${{ env.appName }}" >> $GITHUB_STEP_SUMMARY
           echo "- Environment=${{ inputs.environment }}" >> $GITHUB_STEP_SUMMARY
           echo "- Version=${{ env.appVersion }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -190,7 +190,7 @@ jobs:
           echo "ingressWhitelist=$ingressWhitelist" >> $env:GITHUB_ENV
           echo "adminIngressWhitelist=$adminIngressWhitelist" >> $env:GITHUB_ENV
           echo "release=$release" >> $env:GITHUB_ENV
-          echo "containerRegistry=$containerRegistry" >> $env:GITHUB_OUTPUT
+          echo "containerRegistry=$containerRegistry" >> $env:GITHUB_ENV
 
       - name: Login via Az module
         uses: azure/login@v1.4.7
@@ -251,11 +251,6 @@ jobs:
           container-registry-username: ${{ secrets.registryUserName  }}
           container-registry-password: ${{ secrets.registryPassword  }}
           secret-name: "${{ env.imagePullSecret }}"
-
-      - name: Encrypt Azure Container Registry value
-        run: |
-          containerRegistry=$(gpg --symmetric --batch --passphrase "${{ secrets.registryPassword }}" --output - <(echo "${{ steps.setenvs.outputs.containerRegistry }}"))
-          echo "containerRegistry=$containerRegistry" >> $env:GITHUB_ENV
 
     outputs:
       appName: ${{ env.appName }}
@@ -340,15 +335,10 @@ jobs:
             echo "buildArguments=$buildArguments" >> $env:GITHUB_ENV
           azPSVersion: 'latest'
 
-      - name: Decrypt Azure Container Registry value
-        run: |
-          containerRegistry=$(gpg --decrypt --quiet --batch --passphrase "${{ secrets.registryPassword }}" --output - <(echo "${{ needs.setup.outputs.containerRegistry }}" | base64 --decode))
-          echo "containerRegistry=$containerRegistry" >> $env:GITHUB_ENV
-
       - name: Login to Azure Container Registry
         uses: Azure/docker-login@v1.0.1
         with:
-          login-server: "${{ env.containerRegistry }}"
+          login-server: "${{ needs.setup.outputs.containerRegistry }}"
           username: ${{ secrets.registryUserName }}
           password: ${{ secrets.registryPassword }}
 

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -425,17 +425,17 @@ jobs:
 
       - name: Output summary
         run: |
-          echo "### \"${{ env.appName }}\" Deployment Details" >> $GITHUB_STEP_SUMMARY
-          echo "- ApplicationName: \"${{ env.appName }}\"" >> $GITHUB_STEP_SUMMARY
-          echo "- Environment: \"${{ inputs.environment }}\"" >> $GITHUB_STEP_SUMMARY
-          echo "- Version: \"${{ env.appVersion }}\"" >> $GITHUB_STEP_SUMMARY
-          echo "- KeyVault: \"${{ inputs.environmentKeyVault }}\"" >> $GITHUB_STEP_SUMMARY
-          echo "- HostName: \"${{ env.hostName }}\"" >> $GITHUB_STEP_SUMMARY
-          echo "- DomainName: \"${{ env.domainName }}\"" >> $GITHUB_STEP_SUMMARY
-          echo "- IngressFqdn: \"${{ env.ingress }}\"" >> $GITHUB_STEP_SUMMARY
-          echo "- HealthCheckPath: \"${{ env.appHealthCheck }}\"" >> $GITHUB_STEP_SUMMARY
-          echo "- AksIngress: \"${{ inputs.aksIngressFqdn }}\"" >> $GITHUB_STEP_SUMMARY
-          echo "- Cluster: \"${{ inputs.clusterName }}\"" >> $GITHUB_STEP_SUMMARY
-          echo "- ClusterResourceGroup: \"${{ inputs.clusterResourceGroup }}\"" >> $GITHUB_STEP_SUMMARY
-          echo "- ConfigSecret: \"${{ env.configSecret }}\"" >> $GITHUB_STEP_SUMMARY
-          echo "- ConfigMap: \"${{ env.configMap }}\"" >> $GITHUB_STEP_SUMMARY
+          echo "### \""${{ env.appName }}"\" Deployment Details" >> $GITHUB_STEP_SUMMARY
+          echo "- ApplicationName: \""${{ env.appName }}"\"" >> $GITHUB_STEP_SUMMARY
+          echo "- Environment: \""${{ inputs.environment }}"\"" >> $GITHUB_STEP_SUMMARY
+          echo "- Version: \""${{ env.appVersion }}"\"" >> $GITHUB_STEP_SUMMARY
+          echo "- KeyVault: \""${{ inputs.environmentKeyVault }}"\"" >> $GITHUB_STEP_SUMMARY
+          echo "- HostName: \""${{ env.hostName }}"\"" >> $GITHUB_STEP_SUMMARY
+          echo "- DomainName: \""${{ env.domainName }}"\"" >> $GITHUB_STEP_SUMMARY
+          echo "- IngressFqdn: \""${{ env.ingress }}"\"" >> $GITHUB_STEP_SUMMARY
+          echo "- HealthCheckPath: \""${{ env.appHealthCheck }}"\"" >> $GITHUB_STEP_SUMMARY
+          echo "- AksIngress: \""${{ inputs.aksIngressFqdn }}"\"" >> $GITHUB_STEP_SUMMARY
+          echo "- Cluster: \""${{ inputs.clusterName }}"\"" >> $GITHUB_STEP_SUMMARY
+          echo "- ClusterResourceGroup: \""${{ inputs.clusterResourceGroup }}"\"" >> $GITHUB_STEP_SUMMARY
+          echo "- ConfigSecret: \""${{ env.configSecret }}"\"" >> $GITHUB_STEP_SUMMARY
+          echo "- ConfigMap: \""${{ env.configMap }}"\"" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -424,8 +424,9 @@ jobs:
           connection_string: "AccountName=${{ inputs.storageAccountName }};AccountKey=${{ secrets.storageAccountKey }}"
 
       - name: Output summary
-        # shellcheck disable=SC2059
         run: |
+          # shellcheck disable=SC2059
+          
           echo "### ${{ env.appName }} Deployment Details" >> $GITHUB_STEP_SUMMARY
           echo "- ApplicationName:${{ env.appName }}" >> $GITHUB_STEP_SUMMARY
           echo "- Environment=${{ inputs.environment }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -103,9 +103,6 @@ on:
       webAuthenticationUsername:
         required: false
 
-permissions:
-      id-token: write
-
 jobs:
   setup:
     name: 'Prepare for build'

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -194,7 +194,7 @@ jobs:
 
       - name: Encrypt Azure Container Registry value
         run: |
-          containerRegistry=$(gpg --symmetric --batch --passphrase "${{ secrets.registryPassword }}" --output - <(echo "${{ steps.setenvs.outputs.containerRegistry }}")
+          containerRegistry=$(gpg --symmetric --batch --passphrase "${{ secrets.registryPassword }}" --output - <(echo "${{ steps.setenvs.outputs.containerRegistry }}"))
           echo "containerRegistry=$containerRegistry" >> $env:GITHUB_ENV
 
       - name: Login via Az module

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -425,17 +425,17 @@ jobs:
 
       - name: Output summary
         run: |
-          echo '### "${{ env.appName }}" Deployment Details' >> $GITHUB_STEP_SUMMARY
-          echo '- ApplicationName: "${{ env.appName }}"' >> $GITHUB_STEP_SUMMARY
-          echo '- Environment: "${{ inputs.environment }}"' >> $GITHUB_STEP_SUMMARY
-          echo '- Version: "${{ env.appVersion }}"' >> $GITHUB_STEP_SUMMARY
-          echo '- KeyVault: "${{ inputs.environmentKeyVault }}"' >> $GITHUB_STEP_SUMMARY
-          echo '- HostName: "${{ env.hostName }}"' >> $GITHUB_STEP_SUMMARY
-          echo '- DomainName: "${{ env.domainName }}"' >> $GITHUB_STEP_SUMMARY
-          echo '- IngressFqdn: "${{ env.ingress }}"' >> $GITHUB_STEP_SUMMARY
-          echo '- HealthCheckPath: "${{ env.appHealthCheck }}"' >> $GITHUB_STEP_SUMMARY
-          echo '- AksIngress: "${{ inputs.aksIngressFqdn }}"' >> $GITHUB_STEP_SUMMARY
-          echo '- Cluster: "${{ inputs.clusterName }}"' >> $GITHUB_STEP_SUMMARY
-          echo '- ClusterResourceGroup: "${{ inputs.clusterResourceGroup }}"' >> $GITHUB_STEP_SUMMARY
-          echo '- ConfigSecret: "${{ env.configSecret }}"' >> $GITHUB_STEP_SUMMARY
-          echo '- ConfigMap: "${{ env.configMap }}"' >> $GITHUB_STEP_SUMMARY
+          echo "### "${{ env.appName }}" Deployment Details" >> $GITHUB_STEP_SUMMARY
+          echo "- ApplicationName: "${{ env.appName }}"" >> $GITHUB_STEP_SUMMARY
+          echo "- Environment: "${{ inputs.environment }}"" >> $GITHUB_STEP_SUMMARY
+          echo "- Version: "${{ env.appVersion }}"' >> $GITHUB_STEP_SUMMARY
+          echo "- KeyVault: "${{ inputs.environmentKeyVault }}"" >> $GITHUB_STEP_SUMMARY
+          echo "- HostName: "${{ env.hostName }}"" >> $GITHUB_STEP_SUMMARY
+          echo "- DomainName: "${{ env.domainName }}"" >> $GITHUB_STEP_SUMMARY
+          echo "- IngressFqdn: "${{ env.ingress }}"" >> $GITHUB_STEP_SUMMARY
+          echo "- HealthCheckPath: "${{ env.appHealthCheck }}"" >> $GITHUB_STEP_SUMMARY
+          echo "- AksIngress: "${{ inputs.aksIngressFqdn }}"" >> $GITHUB_STEP_SUMMARY
+          echo "- Cluster: "${{ inputs.clusterName }}"" >> $GITHUB_STEP_SUMMARY
+          echo "- ClusterResourceGroup: "${{ inputs.clusterResourceGroup }}"" >> $GITHUB_STEP_SUMMARY
+          echo "- ConfigSecret: "${{ env.configSecret }}"" >> $GITHUB_STEP_SUMMARY
+          echo "- ConfigMap: "${{ env.configMap }}"" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -195,6 +195,7 @@ jobs:
       - name: Encrypt Azure Container Registry value
         run: |
           containerRegistry=$(gpg --symmetric --batch --passphrase "${{ secrets.registryPassword }}" --output - <(echo "${{ steps.setenvs.outputs.containerRegistry }}"))
+          echo "::add-mask::$containerRegistry"
           echo "containerRegistry=$containerRegistry" >> $env:GITHUB_ENV
 
       - name: Login via Az module
@@ -252,7 +253,7 @@ jobs:
       - name: Create k8s Image Pull Secret
         uses: Azure/k8s-create-secret@v4.0
         with:
-          container-registry-url: "${{ env.containerRegistry }}"
+          container-registry-url: "${{ steps.setenvs.outputs.containerRegistry }}"
           container-registry-username: ${{ secrets.registryUserName  }}
           container-registry-password: ${{ secrets.registryPassword  }}
           secret-name: "${{ env.imagePullSecret }}"

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -84,11 +84,7 @@ on:
         description: 'Add the environment name to the front of the hostname (for DNS)'
         default: true
     secrets:
-      azureTenantId:
-        required: true
-      azureClientId:
-        required: true
-      azureSubscriptionId:
+      azureCredentials:
         required: true
       registryUserName:
         required: true
@@ -199,9 +195,7 @@ jobs:
       - name: Login via Az module
         uses: azure/login@v1.4.7
         with:
-          client-id: ${{ secrets.azureClientId }}
-          tenant-id: ${{ secrets.azureTenantId }}
-          subscription-id: ${{ secrets.azureSubscriptionId }}
+          creds: "${{ secrets.azureCredentials }}"
           enable-AzPSSession: true
 
       - name: Generate .env file from Azure Key Vaults
@@ -300,9 +294,7 @@ jobs:
       - name: Login via Az module
         uses: azure/login@v1.4.7
         with:
-          client-id: ${{ secrets.azureClientId }}
-          tenant-id: ${{ secrets.azureTenantId }}
-          subscription-id: ${{ secrets.azureSubscriptionId }}
+          creds: "${{ secrets.azureCredentials }}"
           enable-AzPSSession: true
 
       - name: Generate .env file from Azure Key Vaults
@@ -443,9 +435,7 @@ jobs:
       - name: Login via Az module
         uses: azure/login@v1.4.7
         with:
-          client-id: ${{ secrets.azureClientId }}
-          tenant-id: ${{ secrets.azureTenantId }}
-          subscription-id: ${{ secrets.azureSubscriptionId }}
+          creds: "${{ secrets.azureCredentials }}"
           enable-AzPSSession: true
 
       - name: Set target AKS cluster
@@ -473,15 +463,6 @@ jobs:
     continue-on-error: false
     environment: ${{ inputs.environment }}
     steps:
-
-      - name: Login via Az module
-        uses: azure/login@v1.4.7
-        with:
-          client-id: ${{ secrets.azureClientId }}
-          tenant-id: ${{ secrets.azureTenantId }}
-          subscription-id: ${{ secrets.azureSubscriptionId }}
-          enable-AzPSSession: true
-
       - name: Create or Update Public DNS Record
         uses: azure/powershell@v1.2.0
         with:

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -425,19 +425,19 @@ jobs:
 
       - name: Output summary
         run: |
-          ApplicationName=${{ env.appName }}
-          Environment=${{ inputs.environment }}
-          Version=${{ env.appVersion }}
-          KeyVault=${{ inputs.environmentKeyVault }}
-          HostName=${{ env.hostName }}
-          DomainName=${{ env.domainName }}
-          IngressFqdn=${{ env.ingress }}
-          HealthCheckPath=${{ env.appHealthCheck }}
-          AksIngress=${{ inputs.aksIngressFqdn }}
-          Cluster=${{ inputs.clusterName }}
-          ClusterResourceGroup=${{ inputs.clusterResourceGroup }}
-          ConfigSecret=${{ env.configSecret }}
-          ConfigMap=${{ env.configMap }}
+          appName=${{ env.appName }}
+          environment=${{ inputs.environment }}
+          appVersion=${{ env.appVersion }}
+          environmentKeyVault=${{ inputs.environmentKeyVault }}
+          hostName=${{ env.hostName }}
+          domainName=${{ env.domainName }}
+          ingress=${{ env.ingress }}
+          appHealthCheck=${{ env.appHealthCheck }}
+          aksIngressFqdn=${{ inputs.aksIngressFqdn }}
+          clusterName=${{ inputs.clusterName }}
+          clusterResourceGroup=${{ inputs.clusterResourceGroup }}
+          configSecret=${{ env.configSecret }}
+          configMap=${{ env.configMap }}
 
           echo "### $appName Deployment Details" >> $GITHUB_STEP_SUMMARY
           echo "- ApplicationName: $appName" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -104,8 +104,7 @@ on:
         required: false
 
 permissions:
-  id-token: write
-  contents: read
+      id-token: write
 
 jobs:
   setup:

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -199,6 +199,19 @@ jobs:
           creds: "${{ secrets.azureCredentials }}"
           enable-AzPSSession: true
 
+      - name: Generate .env file from Azure Key Vaults
+        uses: azure/powershell@v1.2.0
+        with:
+          inlineScript: |
+            $envSecrets = (Get-AzKeyVaultSecret -VaultName "${{ inputs.environmentKeyVault }}"  | Where-Object {($_.ContentType -contains 'Env') -or ($_.ContentType -contains 'BuildArg Env')}).Name
+            $envSecrets | ForEach-Object {
+                $envName = $_.ToUpper()
+                $envName = $envName.Replace("-","_")
+                $envSecret = (Get-AzKeyVaultSecret -VaultName $KeyVaultName -Name $_).secretvalue | ConvertFrom-SecureString -AsPlainText
+                $envFileContent = $envName + "=" + $envSecret
+                Add-Content -Path ".env" -Value $envFileContent
+            }
+
       - name: Set target AKS cluster
         uses: Azure/aks-set-context@v3.2
         with:
@@ -284,48 +297,36 @@ jobs:
           creds: "${{ secrets.azureCredentials }}"
           enable-AzPSSession: true
 
-      - name: Get Secrets from Key Vaults
-        id: getsecrets
+      - name: Generate .env file from Azure Key Vaults
         uses: azure/powershell@v1.2.0
         with:
           inlineScript: |
-            Function Get-EnvSecrets {
-              param (
-                  $KeyVaultName
-              )
-                #$secretTable = @{}
-                $envSecrets = (Get-AzKeyVaultSecret -VaultName $KeyVaultName  | Where-Object {($_.ContentType -contains 'Env') -or ($_.ContentType -contains 'BuildArg Env')}).Name
-                $envSecrets | ForEach-Object {
-                    $envName = $_.ToUpper()
-                    $envName = $envName.Replace("-","_")
-                    $envSecret = (Get-AzKeyVaultSecret -VaultName $KeyVaultName -Name $_).secretvalue | ConvertFrom-SecureString -AsPlainText
-                    $envFileContent = $envName + "=" + $envSecret
-                    Add-Content -Path ".env" -Value $envFileContent
-                }
-                return $kubernetesSecret
-              }
-            Function Get-BuildArgSecrets {
-              param (
-                  $KeyVaultName
-              )
-                $buildSecrets = (Get-AzKeyVaultSecret -VaultName $KeyVaultName  | Where-Object {($_.ContentType -contains 'BuildArg') -or ($_.ContentType -contains 'BuildArg Env')}).Name
-                if ($buildSecrets.Count -gt 0) {
-                    $buildArgPredicate = ' --build-arg '
-                }
-                else {
-                    return
-                }
-                $buildSecrets | ForEach-Object {
-                    $argName = $_.ToUpper()
-                    $argName = $argName.Replace("-","_")
-                    $argSecret = (Get-AzKeyVaultSecret -VaultName $KeyVaultName -Name $_).secretvalue | ConvertFrom-SecureString -AsPlainText
-                    $buildArgs = $buildArgs + $buildArgPredicate + $argName + "=" + $argSecret
-                }
-                return $buildArgs
+            $envSecrets = (Get-AzKeyVaultSecret -VaultName "${{ inputs.environmentKeyVault }}"  | Where-Object {($_.ContentType -contains 'Env') -or ($_.ContentType -contains 'BuildArg Env')}).Name
+            $envSecrets | ForEach-Object {
+                $envName = $_.ToUpper()
+                $envName = $envName.Replace("-","_")
+                $envSecret = (Get-AzKeyVaultSecret -VaultName $KeyVaultName -Name $_).secretvalue | ConvertFrom-SecureString -AsPlainText
+                $envFileContent = $envName + "=" + $envSecret
+                Add-Content -Path ".env" -Value $envFileContent
             }
-            Get-EnvSecrets -KeyVaultName "${{ inputs.environmentKeyVault }}"
-            Write-Host $k8sSecret
-            $buildArguments = Get-BuildArgSecrets -KeyVaultName "${{ inputs.environmentKeyVault }}"
+
+      - name: Generate build args from Azure Key Vaults
+        uses: azure/powershell@v1.2.0
+        with:
+          inlineScript: |
+            $buildSecrets = (Get-AzKeyVaultSecret -VaultName "${{ inputs.environmentKeyVault }}"  | Where-Object {($_.ContentType -contains 'BuildArg') -or ($_.ContentType -contains 'BuildArg Env')}).Name
+            if ($buildSecrets.Count -gt 0) {
+                $buildArgPredicate = ' --build-arg '
+            }
+            else {
+                return
+            }
+            $buildSecrets | ForEach-Object {
+                $argName = $_.ToUpper()
+                $argName = $argName.Replace("-","_")
+                $argSecret = (Get-AzKeyVaultSecret -VaultName "${{ inputs.environmentKeyVault }}" -Name $_).secretvalue | ConvertFrom-SecureString -AsPlainText
+                $buildArguments = $buildArguments + $buildArgPredicate + $argName + "=" + $argSecret
+            }
 
             echo "buildArguments=$buildArguments" >> $env:GITHUB_ENV
           azPSVersion: 'latest'

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -192,6 +192,14 @@ jobs:
           echo "release=$release" >> $env:GITHUB_ENV
           echo "containerRegistry=$containerRegistry" >> $GITHUB_OUTPUTS
 
+      - name: Create k8s Image Pull Secret
+        uses: Azure/k8s-create-secret@v4.0
+        with:
+          container-registry-url: "${{ steps.setenvs.outputs.containerRegistry }}"
+          container-registry-username: ${{ secrets.registryUserName  }}
+          container-registry-password: ${{ secrets.registryPassword  }}
+          secret-name: "${{ env.imagePullSecret }}"
+
       - name: Encrypt Azure Container Registry value
         run: |
           containerRegistry=$(gpg --symmetric --batch --passphrase "${{ secrets.registryPassword }}" --output - <(echo "${{ steps.setenvs.outputs.containerRegistry }}"))
@@ -249,14 +257,6 @@ jobs:
             htpasswd -cb auth "${{ secrets.webAuthenticationUsername }}" "${{ secrets.webAuthenticationPassword }}"
             kubectl create secret generic "${{ env.appName }}-basic-auth" --from-file=auth
           }
-
-      - name: Create k8s Image Pull Secret
-        uses: Azure/k8s-create-secret@v4.0
-        with:
-          container-registry-url: "${{ steps.setenvs.outputs.containerRegistry }}"
-          container-registry-username: ${{ secrets.registryUserName  }}
-          container-registry-password: ${{ secrets.registryPassword  }}
-          secret-name: "${{ env.imagePullSecret }}"
 
     outputs:
       appName: ${{ env.appName }}

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -211,6 +211,7 @@ jobs:
                 $envFileContent = $envName + "=" + $envSecret
                 Add-Content -Path ".env" -Value $envFileContent
             }
+          azPSVersion: 'latest'
 
       - name: Set target AKS cluster
         uses: Azure/aks-set-context@v3.2
@@ -309,6 +310,7 @@ jobs:
                 $envFileContent = $envName + "=" + $envSecret
                 Add-Content -Path ".env" -Value $envFileContent
             }
+          azPSVersion: 'latest'
 
       - name: Generate build args from Azure Key Vaults
         uses: azure/powershell@v1.2.0

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -463,6 +463,12 @@ jobs:
     continue-on-error: false
     environment: ${{ inputs.environment }}
     steps:
+      - name: Login via Az module
+        uses: azure/login@v1.4.7
+        with:
+          creds: "${{ secrets.azureCredentials }}"
+          enable-AzPSSession: true
+
       - name: Create or Update Public DNS Record
         uses: azure/powershell@v1.2.0
         with:

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -424,31 +424,19 @@ jobs:
           connection_string: "AccountName=${{ inputs.storageAccountName }};AccountKey=${{ secrets.storageAccountKey }}"
 
       - name: Output summary
+        # shellcheck disable=SC2059
         run: |
-          appName=${{ env.appName }}
-          environment=${{ inputs.environment }}
-          appVersion=${{ env.appVersion }}
-          environmentKeyVault=${{ inputs.environmentKeyVault }}
-          hostName=${{ env.hostName }}
-          domainName=${{ env.domainName }}
-          ingress=${{ env.ingress }}
-          appHealthCheck=${{ env.appHealthCheck }}
-          aksIngressFqdn=${{ inputs.aksIngressFqdn }}
-          clusterName=${{ inputs.clusterName }}
-          clusterResourceGroup=${{ inputs.clusterResourceGroup }}
-          configSecret=${{ env.configSecret }}
-          configMap=${{ env.configMap }}
-
-          echo "### \"$appName\" Deployment Details" >> $GITHUB_STEP_SUMMARY
-          echo "- Environment: \"$environment\"" >> $GITHUB_STEP_SUMMARY
-          echo "- Version: \"$appVersion\"" >> $GITHUB_STEP_SUMMARY
-          echo "- KeyVault: \"$environmentKeyVault\"" >> $GITHUB_STEP_SUMMARY
-          echo "- HostName: \"$hostName\"" >> $GITHUB_STEP_SUMMARY
-          echo "- DomainName: \"$domainName\"" >> $GITHUB_STEP_SUMMARY
-          echo "- IngressFqdn: \"$ingress\"" >> $GITHUB_STEP_SUMMARY
-          echo "- HealthCheckPath: \"$appHealthCheck\"" >> $GITHUB_STEP_SUMMARY
-          echo "- AksIngress: \"$aksIngressFqdn\"" >> $GITHUB_STEP_SUMMARY
-          echo "- Cluster: \"$clusterName\"" >> $GITHUB_STEP_SUMMARY
-          echo "- ClusterResourceGroup: \"$clusterResourceGroup\"" >> $GITHUB_STEP_SUMMARY
-          echo "- ConfigSecret: \"$configSecret\"" >> $GITHUB_STEP_SUMMARY
-          echo "- ConfigMap: \"$configMap\"" >> $GITHUB_STEP_SUMMARY
+          echo "### ${{ env.appName }} Deployment Details" >> $GITHUB_STEP_SUMMARY"
+          echo "- ApplicationName:${{ env.appName }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Environment=${{ inputs.environment }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Version=${{ env.appVersion }}" >> $GITHUB_STEP_SUMMARY
+          echo "- KeyVault=${{ inputs.environmentKeyVault }}" >> $GITHUB_STEP_SUMMARY
+          echo "- HostName=${{ env.hostName }}" >> $GITHUB_STEP_SUMMARY
+          echo "- DomainName=${{ env.domainName }}" >> $GITHUB_STEP_SUMMARY
+          echo "- IngressFqdn=${{ env.ingress }}" >> $GITHUB_STEP_SUMMARY
+          echo "- HealthCheckPath=${{ env.appHealthCheck }}" >> $GITHUB_STEP_SUMMARY
+          echo "- AksIngress=${{ inputs.aksIngressFqdn }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Cluster=${{ inputs.clusterName }}" >> $GITHUB_STEP_SUMMARY
+          echo "- ClusterResourceGroup=${{ inputs.clusterResourceGroup }}" >> $GITHUB_STEP_SUMMARY
+          echo "- ConfigSecret=${{ env.configSecret }}" >> $GITHUB_STEP_SUMMARY
+          echo "- ConfigMap=${{ env.configMap }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/workflow-linter.yaml
+++ b/.github/workflows/workflow-linter.yaml
@@ -12,5 +12,5 @@ jobs:
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
         shell: bash
       - name: Check workflow files
-        run: ${{ steps.get_actionlint.outputs.executable }} -color -ignore "SC2086"
+        run: ${{ steps.get_actionlint.outputs.executable }} -color -ignore "SC2086,SC2129"
         shell: bash

--- a/.github/workflows/workflow-linter.yaml
+++ b/.github/workflows/workflow-linter.yaml
@@ -12,5 +12,5 @@ jobs:
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
         shell: bash
       - name: Check workflow files
-        run: ${{ steps.get_actionlint.outputs.executable }} -color
+        run: ${{ steps.get_actionlint.outputs.executable }} -color -ignore "SC2086"
         shell: bash

--- a/.github/workflows/workflow-linter.yaml
+++ b/.github/workflows/workflow-linter.yaml
@@ -12,5 +12,5 @@ jobs:
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
         shell: bash
       - name: Check workflow files
-        run: ${{ steps.get_actionlint.outputs.executable }} -color -ignore "SC2086,SC2129"
+        run: ${{ steps.get_actionlint.outputs.executable }} -color -ignore "SC2086" -ignore "SC2129"
         shell: bash

--- a/README.md
+++ b/README.md
@@ -1,28 +1,75 @@
 # reusable_workflows
-Reusabe GitHub Workflows
 
-## Summary
+[![Lint workflows](https://github.com/Andrews-McMeel-Universal/reusable_workflows/actions/workflows/workflow-linter.yaml/badge.svg)](https://github.com/Andrews-McMeel-Universal/reusable_workflows/actions/workflows/workflow-linter.yaml)
 
-Reusable workflows can be called from other workflows to deploy applications to Azure Kubernetes.   There are currently 3 workflows:
+Welcome to Reusable GitHub Workflows!
 
-- aks-deploy.yaml
-The deployment workflow.   This must be ran before other workflows.   This workflow checks the code out, parses the charts.yaml and values.yaml in the application's helm charts for 
-information about the application.   Reads the specified Azure KeyVaults for secrets and build arguments for the application.  Creates public dns records for the application. Creates any K8s secrets or Configmaps specified for the application.  Builds docker image for the application.   Pushes the docker image to Azure's container repository.   Then bakes the application's helm charts, and then deploys the application to Azure Kubernetes.   Upon a successful deployment, the workflow records the deployment information in Azure Storage Tables for use by subsequent workflows.
+Reusable workflows can be called from other workflows to run automated tasks against different applications.
+## Available Reusable Workflows
 
-- update-addns.yaml
-Updates internal Active Directory DNS.  Reads the Azure Storage Table for application information and then updates Active Directory DNS.   This workflow runs on a self hosted runner.
 
-- updateazureapimanagement.yaml
-Updates Azure API Management.   Reads the Azure Storage Table for application information and then updates Azure API Management with the swagger.json Open API Spec.  This workflow should only be used for backend services, not a UI as a UI won't have an API. 
+### aks-deploy.yaml
 
-### Contributing
+[![Test AKS Deploy](https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/actions/workflows/test-aks-deploy.yaml/badge.svg)](https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/actions/workflows/test-aks-deploy.yaml)
 
-Also release any workflow changes as a new release as changes may break existing workflows.
+This workflow is used for deploying an application to the Azure Kubernetes Services cluster.
 
-#### Using
-You can call a reusable workflow with the "uses:" prefix in the calling workflow.  
+#### Example:
+```
+name: 'Test AKS Deploy'
 
-Example:
-uses: Andrews-McMeel-Universal/reusable_workflows/.github/workflows/aks-deploy.yaml@1.0
+...
 
+jobs:
+  deploy:
+    name: 'AKS Deployment'
+    uses: Andrews-McMeel-Universal/reusable_workflows/.github/workflows/aks-deploy.yaml@2.2.0
+    with:
+      repositoryName: ${{ github.event.repository.name }}
+      environment: development
+      environmentKeyVault: amu-shared
+      clusterName: amuaks201
+      clusterResourceGroup: AMU_AKS_201
+      aksIngressFqdn: amuaks201-production-ingress.centralus.cloudapp.azure.com.
+      dnsResourceGroup: AMU_DNS_RG
+      chartsPath: ./deployments/charts
+      dockerFilePath: .
+      dockerImageName: ${{ github.event.repository.name }}
+      dockerImageTag: ${{ github.sha }}
+      storageAccountName: amucloudapps
+      appInfoTableName: DeployedApplications
+
+    secrets:
+      azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
+      registryUserName: ${{ secrets.AMUAPPIMAGES201_USERNAME }}
+      registryPassword: ${{ secrets.AMUAPPIMAGES201_PASSWORD }}
+      registryHostname: ${{ secrets.AMUAPPIMAGES201_HOSTNAME }}
+      storageAccountKey: ${{ secrets.AMUCLOUDAPPS_KEY }}
+```
+
+### b2c-build-and-deploy.yaml
+This workflow can be used to consolidate the workflows in the  https://github.com/Andrews-McMeel-Universal/azure-b2c_auth repository. This repository has it's own workflow due to the complexities involved when building the application along with the multi-product and multi-environment structure.
+
+### purge-cdn.yaml
+This workflow purges the cache in an Azure CDN.
+
+### update-addns.yaml
+This workflow updates internal Active Directory DNS.  Reads the Azure Storage Table for application information and then updates Active Directory DNS.   This workflow runs on a self hosted runner.
+
+### updateazureapimanagement.yaml
+This workflow updates Azure API Management.   Reads the Azure Storage Table for application information and then updates Azure API Management with the swagger.json Open API Spec.  This workflow should only be used for backend services, not a UI as a UI won't have an API. 
+
+### workflow-linter.yaml
+This workflow is used exclusively for linting the workflows to make sure there aren't any syntax errors. Please see more details under the testing section.
+
+
+## Testing
+
+This repository is set up with a linting workflow that runs through all workflows to make sure there are not any syntax errors.
+
+On top of this, the https://github.com/Andrews-McMeel-Universal/reusable_workflows-test repository is used for building out test applications using the workflows to confirm that there aren't any errors during runtime.
+
+## Contributing
+
+Please create feature branches that are then pushed into the main branches after successful tests. Once a new release is created, please update repositories to use the latest workflow.
 


### PR DESCRIPTION
# Overall Changes
- Created CODEOWNERS, PR template, and dependabot configurations.
- Updated README to have more updated information about available workflows and what they do. Also added status badges to make it easier to tell if the latest releases are working.

## AKS Deploy changes
- Split out AKS deployment workflow into `setup`, `build`, `deploy`, and `update-records` steps.
- Implemented build artifacts for the the bake Helm templates step.
- Added a new `registryHostName` secret to the AKS Deploy workflow since I could no longer use the image.repository value from the Helm `values.yaml` file.
- Added new "Deployment Summary" step at the end of the AKS Deploy workflow that gives a summary of what was deployed and its properties.