### PR TITLE
[DEVOPS] fix release var in setenvs step

### DIFF
--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -187,7 +187,7 @@ jobs:
             }
           }
           
-          $release = "$appName-${{ github.sha }}".Substring(0,53)
+          $release = "$appName-${{ github.sha }}" -replace '(^.{53})(.*$)','$1'
           $release = ($release -replace '[^-\p{L}\p{Nd}]', '').ToLower() -replace '^-', '' -replace '-$', ''
 
           echo "appName=$appName" >> $env:GITHUB_ENV


### PR DESCRIPTION
The 2.1.13.1 release was made to revert the changes made to set the variable in PowerShell entirely and to move it back the inline bash script. This PR is to move it back to the PowerShell setenvs step and fix the errors it was creating due to too short of an appName value.

Here's a GitHub action that was breaking due to this bug: https://github.com/Andrews-McMeel-Universal/uexpress_ui/actions/runs/4048471886/jobs/6963921472

- Fixing the release var setting in the "Checkout Code and Variables for the environment" step.
