### PR TITLE
[DEVOPS] Fix quoting issue with workflow_call inputs

### DIFF
--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -166,9 +166,8 @@ jobs:
           $appDeployDate = Get-Date
           $ingress = $appConfig.ingress.host
           $domainName = ($ingress.Split('.') | Select-Object -Last 2) -join '.'
-          $environmentIngress = "${{ inputs.environmentIngress }}"
-          $hostName = $ingress -replace $domainName, ''
-          $hostName = $hostName -replace "\.$", ""
+          $environmentIngress = "${{ inputs.environmentIngress }}" -replace '"', '' -replace "'", ""
+          $hostName = $ingress -replace $domainName, '' -replace "\.$", ""
           $ingressWhitelist = $($appConfig.ingress.annotations)."nginx.ingress.kubernetes.io/whitelist-source-range"
           $adminIngressWhitelist = $($appConfig.adminingress.annotations)."nginx.ingress.kubernetes.io/whitelist-source-range"
 
@@ -309,7 +308,7 @@ jobs:
 
       - name: Create values override file
         run: |
-          WEB_AUTHENTICATION="${{ inputs.webAuthentication }}"
+          WEB_AUTHENTICATION=$(echo "${{ inputs.webAuthentication }}" | tr -d "'" | tr -d '"')
           INGRESS_WHITELIST_ENV="${{ env.ingressWhitelist }}"
           ADMIN_INGRESS_WHITELIST_ENV="${{ env.adminIngressWhitelist }}"
           if [[ -n "${INGRESS_WHITELIST_ENV}" ]] ; then


### PR DESCRIPTION
Fixing a bug where, if quotes are included in the string object of the workflow inputs, any comparisons using those inputs can break.

Test workflow: [![AKS Deployment](https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/actions/workflows/aks-deployment.yml/badge.svg?branch=aks-deploy-2.1.16)](https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/actions/workflows/aks-deployment.yml)