### PR TITLE
DEVOPS-add-web-auth-error-message

### DIFF
--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -280,6 +280,14 @@ jobs:
       - name: Add GitHub secrets to k8s
         shell: pwsh
         run: |
+          WEB_AUTHENTICATION_USERNAME="${{ secrets.webAuthenticationUsername }}"
+          WEB_AUTHENTICATION_PASSWORD="${{ secrets.webAuthenticationPassword }}"
+
+          if [[ -z $WEB_AUTHENTICATION_USERNAME ]] || [[ -z $WEB_AUTHENTICATION_PASSWORD ]]; then
+              echo "::error::Please make sure the 'webAuthenticationUsername' and 'webAuthenticationPassword' environment secrets are set."
+              exit 1
+          fi
+
           if (kubectl get secret | Select-String "${{ env.configSecret }}") {
             kubectl delete secret "${{ env.configSecret }}"
           }
@@ -289,7 +297,7 @@ jobs:
             if (kubectl get secret | Select-String "${{ env.appName }}-basic-auth") {
               kubectl delete secret "${{ env.appName }}-basic-auth"
             }
-            htpasswd -cb auth "${{ secrets.webAuthenticationUsername }}" "${{ secrets.webAuthenticationPassword }}"
+            htpasswd -cb auth "$WEB_AUTHENTICATION_USERNAME" "$WEB_AUTHENTICATION_PASSWORD"
             kubectl create secret generic "${{ env.appName }}-basic-auth" --from-file=auth
           }
 

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -289,10 +289,10 @@ jobs:
             WEB_AUTHENTICATION_USERNAME="${{ secrets.webAuthenticationUsername }}"
             WEB_AUTHENTICATION_PASSWORD="${{ secrets.webAuthenticationPassword }}"
 
-            if [[ -z $WEB_AUTHENTICATION_USERNAME ]] || [[ -z $WEB_AUTHENTICATION_PASSWORD ]]; then
+            if (!$WEB_AUTHENTICATION_USERNAME -or !$WEB_AUTHENTICATION_PASSWORD) {
                 echo "::error::Please make sure the 'webAuthenticationUsername' and 'webAuthenticationPassword' environment secrets are set."
                 exit 1
-            fi
+            }
 
             if (kubectl get secret | Select-String "${{ env.appName }}-basic-auth") {
               kubectl delete secret "${{ env.appName }}-basic-auth"

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -286,10 +286,7 @@ jobs:
           kubectl create secret generic "${{ env.configSecret }}" --from-env-file .env
 
           if ( "${{ inputs.webAuthentication }}" -eq "true") {
-            $webAuthenticationUsername"${{ secrets.webAuthenticationUsername }}"
-            $webAuthenticationPassword="${{ secrets.webAuthenticationPassword }}"
-
-            if (!$webAuthenticationUsername -or !$webAuthenticationPassword) {
+            if (!"${{ secrets.webAuthenticationUsername }}" -or !"${{ secrets.webAuthenticationPassword }}") {
                 echo "::error::Please make sure the 'webAuthenticationUsername' and 'webAuthenticationPassword' environment secrets are set."
                 exit 1
             }
@@ -297,7 +294,7 @@ jobs:
             if (kubectl get secret | Select-String "${{ env.appName }}-basic-auth") {
               kubectl delete secret "${{ env.appName }}-basic-auth"
             }
-            htpasswd -cb auth "$webAuthenticationUsername" "$webAuthenticationPassword"
+            htpasswd -cb auth "${{ secrets.webAuthenticationUsername }}" "${{ secrets.webAuthenticationPassword }}"
             kubectl create secret generic "${{ env.appName }}-basic-auth" --from-file=auth
           }
 

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -287,7 +287,7 @@ jobs:
 
           if ( "${{ inputs.webAuthentication }}" -eq "true") {
             if (!"${{ secrets.webAuthenticationUsername }}" -or !"${{ secrets.webAuthenticationPassword }}") {
-                echo "::error::Please make sure the 'webAuthenticationUsername' and 'webAuthenticationPassword' environment secrets are set."
+                echo "::error::Please make sure the 'webAuthenticationUsername' and 'webAuthenticationPassword' GitHub environment secrets are set correctly."
                 exit 1
             }
 

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -280,20 +280,20 @@ jobs:
       - name: Add GitHub secrets to k8s
         shell: pwsh
         run: |
-          WEB_AUTHENTICATION_USERNAME="${{ secrets.webAuthenticationUsername }}"
-          WEB_AUTHENTICATION_PASSWORD="${{ secrets.webAuthenticationPassword }}"
-
-          if [[ -z $WEB_AUTHENTICATION_USERNAME ]] || [[ -z $WEB_AUTHENTICATION_PASSWORD ]]; then
-              echo "::error::Please make sure the 'webAuthenticationUsername' and 'webAuthenticationPassword' environment secrets are set."
-              exit 1
-          fi
-
           if (kubectl get secret | Select-String "${{ env.configSecret }}") {
             kubectl delete secret "${{ env.configSecret }}"
           }
           kubectl create secret generic "${{ env.configSecret }}" --from-env-file .env
 
           if ( "${{ inputs.webAuthentication }}" -eq "true") {
+            WEB_AUTHENTICATION_USERNAME="${{ secrets.webAuthenticationUsername }}"
+            WEB_AUTHENTICATION_PASSWORD="${{ secrets.webAuthenticationPassword }}"
+
+            if [[ -z $WEB_AUTHENTICATION_USERNAME ]] || [[ -z $WEB_AUTHENTICATION_PASSWORD ]]; then
+                echo "::error::Please make sure the 'webAuthenticationUsername' and 'webAuthenticationPassword' environment secrets are set."
+                exit 1
+            fi
+
             if (kubectl get secret | Select-String "${{ env.appName }}-basic-auth") {
               kubectl delete secret "${{ env.appName }}-basic-auth"
             }

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -286,10 +286,10 @@ jobs:
           kubectl create secret generic "${{ env.configSecret }}" --from-env-file .env
 
           if ( "${{ inputs.webAuthentication }}" -eq "true") {
-            WEB_AUTHENTICATION_USERNAME="${{ secrets.webAuthenticationUsername }}"
-            WEB_AUTHENTICATION_PASSWORD="${{ secrets.webAuthenticationPassword }}"
+            $webAuthenticationUsername"${{ secrets.webAuthenticationUsername }}"
+            $webAuthenticationPassword="${{ secrets.webAuthenticationPassword }}"
 
-            if (!$WEB_AUTHENTICATION_USERNAME -or !$WEB_AUTHENTICATION_PASSWORD) {
+            if (!$webAuthenticationUsername -or !$webAuthenticationPassword) {
                 echo "::error::Please make sure the 'webAuthenticationUsername' and 'webAuthenticationPassword' environment secrets are set."
                 exit 1
             }
@@ -297,7 +297,7 @@ jobs:
             if (kubectl get secret | Select-String "${{ env.appName }}-basic-auth") {
               kubectl delete secret "${{ env.appName }}-basic-auth"
             }
-            htpasswd -cb auth "$WEB_AUTHENTICATION_USERNAME" "$WEB_AUTHENTICATION_PASSWORD"
+            htpasswd -cb auth "$webAuthenticationUsername" "$webAuthenticationPassword"
             kubectl create secret generic "${{ env.appName }}-basic-auth" --from-file=auth
           }
 

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -319,16 +319,16 @@ jobs:
           WEB_AUTHENTICATION=$(echo "${{ inputs.webAuthentication }}" | tr -d "'" | tr -d '"')
           INGRESS_WHITELIST_ENV="${{ env.ingressWhitelist }}"
           ADMIN_INGRESS_WHITELIST_ENV="${{ env.adminIngressWhitelist }}"
-          if [[ -n "${INGRESS_WHITELIST_ENV}" ]] ; then
-            INGRESS_WHITELIST="${{ env.ingressWhitelist }}"
-          else
+          if [[ -z "${INGRESS_WHITELIST_ENV}" ]] ; then
             INGRESS_WHITELIST="${{ inputs.ingressWhitelist }}"
+          else
+            INGRESS_WHITELIST="${{ env.ingressWhitelist }}"
           fi
 
-          if [[ -n "${ADMIN_INGRESS_WHITELIST_ENV}" ]] ; then
-            ADMIN_INGRESS_WHITELIST="${{ env.adminIngressWhitelist }}"
-          else
+          if [[ -z "${ADMIN_INGRESS_WHITELIST_ENV}" ]] ; then
             ADMIN_INGRESS_WHITELIST="${{ inputs.adminIngressWhitelist }}"
+          else
+            ADMIN_INGRESS_WHITELIST="${{ env.adminIngressWhitelist }}"
           fi
 
           if [[ "${WEB_AUTHENTICATION}" == "true" ]] ; then
@@ -344,7 +344,7 @@ jobs:
             annotations:
               nginx.ingress.kubernetes.io/whitelist-source-range: "${ADMIN_INGRESS_WHITELIST}"
           EOF
-          elif [[ "${ADMIN_INGRESS_WHITELIST}" != "207.67.20.252" ]] || [[ "${INGRESS_WHITELIST}" != "0.0.0.0/0" ]]; then
+          else
           cat << EOF >> values-override.yaml
           ingress:
             annotations:
@@ -353,13 +353,6 @@ jobs:
           adminingress:
             annotations:
               nginx.ingress.kubernetes.io/whitelist-source-range: "${ADMIN_INGRESS_WHITELIST}"
-          EOF
-          else
-          cat << EOF >> values-override.yaml
-          ingress:
-            annotations:
-              nginx.ingress.kubernetes.io/limit-whitelist: "207.67.20.252"
-              nginx.ingress.kubernetes.io/whitelist-source-range: "${INGRESS_WHITELIST}"
           EOF
           fi
 


### PR DESCRIPTION
Added an error message during the web authentication K8s secret creation to let the user know that the environment secrets have to be set to continue.

Successful test: [![Development AKS Deploy](https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/actions/workflows/aks-development.yml/badge.svg?branch=DEVOPS-add-web-auth-error-message)](https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/actions/workflows/aks-development.yml)

Testing Branch: https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/tree/DEVOPS-add-web-auth-error-message