### PR TITLE
[DEVOPS-206] increased maximumReplicas to 30

### DIFF
--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -49,7 +49,7 @@ on:
         required: false
         type: string
         description: 'Maximum number of replicas for the application HPA.'
-        default: 4
+        default: 30
       storageAccountName:
         required: true
         type: string


### PR DESCRIPTION
- Changed the default value for the `maximumReplicas` input from 4 to 30.

[DEVOPS-206](https://amuniversal.atlassian.net/browse/DEVOPS-206)