### PR TITLE
Default to tagged objects + AD DNS fix again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,12 @@ updates:
     directory: ".github/"
     schedule:
       interval: "weekly"
+      day: "monday"
     labels:
       - "devops"
-      - "dependencies"
     reviewers:
       - "Andrews-McMeel-Universal/devops-engineers"
+    open-pull-requests-limit: 10
+    commit-message:
+      # Prefix all commit messages with "github-actions"
+      prefix: "github-actions"

--- a/.github/workflows/purge-cdn.yaml
+++ b/.github/workflows/purge-cdn.yaml
@@ -34,12 +34,6 @@ jobs:
           creds: "${{ secrets.azureCredentials }}"
           enable-AzPSSession: true
 
-      - name: Check Inputs
-        uses: azure/powershell@v1.2.0
-        with:
-          azPSVersion: "latest"
-          inlineScript: |
-
       - name: Purge CDN cache
         uses: azure/powershell@v1.2.0
         with:

--- a/.github/workflows/purge-cdn.yaml
+++ b/.github/workflows/purge-cdn.yaml
@@ -4,9 +4,21 @@ on:
   workflow_call:
     inputs:
       environment:
-        required: true
+        required: false
         type: string
         description: "Deploy Environment. Can be development, staging, or production."
+      cdnResourceGroup:
+        required: false
+        type: string
+        description: "CDN Resource Group."
+      cdnProfile:
+        required: false
+        type: string
+        description: "CDN Profile."
+      cdnEndpoint:
+        required: false
+        type: string
+        description: "CDN Endpoint."
     secrets:
       azureCredentials:
         required: true
@@ -22,13 +34,40 @@ jobs:
           creds: "${{ secrets.azureCredentials }}"
           enable-AzPSSession: true
 
+      - name: Check Inputs
+        uses: azure/powershell@v1.2.0
+        with:
+          azPSVersion: "latest"
+          inlineScript: |
+
       - name: Purge CDN cache
         uses: azure/powershell@v1.2.0
         with:
           azPSVersion: "latest"
           inlineScript: |
-            $ProfileName = (Get-AzResource -ResourceType Microsoft.Cdn/profiles -Tag @{"environment"="${{ inputs.environment }}"}).Name
-            $ResourceGroup = (Get-AzResource -ResourceType Microsoft.Cdn/profiles -Tag @{"environment"="${{ inputs.environment }}"}).ResourceGroupName
-            $EndpointName = (Get-AzResource -ResourceType Microsoft.Cdn/profiles/endpoints -Tag @{"repository-name"="${{ github.event.repository.name }}"} | Where-Object { $_.Tags."environment" -contains "staging" }).Name -replace ("${ProfileName}/","")
+            if ((!"${{ inputs.environment }}") -and ((!"${{ inputs.cdnResourceGroup }}") -and (!"${{ inputs.cdnProfile }}") -and (!"${{ inputs.cdnEndpoint }}"))) {
+              echo "::error::The environment input or any of the CDN inputs are missing from the workflow call. Please try again"
+              exit 1
+            }
+            if ("${{ inputs.cdnResourceGroup }}") {
+              $ResourceGroup = "${{ inputs.cdnResourceGroup }}"
+            }
+            else {
+              $ResourceGroup = (Get-AzResource -ResourceType Microsoft.Cdn/profiles -Tag @{"environment"="${{ inputs.environment }}"}).ResourceGroupName
+            }
+
+            if ("${{ inputs.cdnProfile }}") {
+              $ProfileName = "${{ inputs.cdnProfile }}"
+            }
+            else {
+              $ProfileName = (Get-AzResource -ResourceType Microsoft.Cdn/profiles -Tag @{"environment"="${{ inputs.environment }}"}).Name
+            }
+
+            if ("${{ inputs.cdnEndpoint }}") {
+              $EndpointName = "${{ inputs.cdnEndpoint }}"
+            }
+            else {
+              $EndpointName = (Get-AzResource -ResourceType Microsoft.Cdn/profiles/endpoints -Tag @{"repository-name"="${{ github.event.repository.name }}"} | Where-Object { $_.Tags."environment" -contains "staging" }).Name -replace ("${ProfileName}/","")
+            }
 
             Clear-AzCdnEndpointContent -EndpointName $EndpointName -ProfileName $ProfileName -ResourceGroupName $ResourceGroup -ContentPath '/*'

--- a/.github/workflows/purge-cdn.yaml
+++ b/.github/workflows/purge-cdn.yaml
@@ -28,6 +28,16 @@ jobs:
     name: Purge CDN Cache
     runs-on: ubuntu-latest
     steps:
+      - name: Check inputs
+        uses: azure/powershell@v1.2.0
+        with:
+          azPSVersion: "latest"
+          inlineScript: |
+            if ((!"${{ inputs.environment }}") -and ((!"${{ inputs.cdnResourceGroup }}") -and (!"${{ inputs.cdnProfile }}") -and (!"${{ inputs.cdnEndpoint }}"))) {
+              echo "::error::The environment input and all of the CDN inputs are missing from the workflow call. Please try again"
+              exit 1
+            }
+
       - name: Login via Az module
         uses: azure/login@v1.4.7
         with:
@@ -39,10 +49,6 @@ jobs:
         with:
           azPSVersion: "latest"
           inlineScript: |
-            if ((!"${{ inputs.environment }}") -and ((!"${{ inputs.cdnResourceGroup }}") -and (!"${{ inputs.cdnProfile }}") -and (!"${{ inputs.cdnEndpoint }}"))) {
-              echo "::error::The environment input or any of the CDN inputs are missing from the workflow call. Please try again"
-              exit 1
-            }
             if ("${{ inputs.cdnResourceGroup }}") {
               $ResourceGroup = "${{ inputs.cdnResourceGroup }}"
             }

--- a/.github/workflows/purge-cdn.yaml
+++ b/.github/workflows/purge-cdn.yaml
@@ -3,18 +3,10 @@ name: Purge Azure CDN
 on:
   workflow_call:
     inputs:
-      cdnResourceGroup:
+      environment:
         required: true
         type: string
-        description: "CDN Resource Group."
-      cdnProfile:
-        required: true
-        type: string
-        description: "CDN Profile."
-      cdnEndpoint:
-        required: true
-        type: string
-        description: "CDN Endpoint."
+        description: "Deploy Environment. Can be development, staging, or production."
     secrets:
       azureCredentials:
         required: true
@@ -23,14 +15,20 @@ jobs:
   purge-cdn:
     name: Purge CDN Cache
     runs-on: ubuntu-latest
-    continue-on-error: false
-    timeout-minutes: 20
     steps:
       - name: Login via Az module
         uses: azure/login@v1.4.7
         with:
           creds: "${{ secrets.azureCredentials }}"
-          enable-AzPSSession: false
+          enable-AzPSSession: true
+
       - name: Purge CDN cache
-        run: |
-          az cdn endpoint purge --resource-group ${{ inputs.cdnResourceGroup }} --profile-name ${{ inputs.cdnProfile }} --name ${{ inputs.cdnEndpoint }} --content-paths '/*'
+        uses: azure/powershell@v1.2.0
+        with:
+          azPSVersion: "latest"
+          inlineScript: |
+            $ProfileName = (Get-AzResource -ResourceType Microsoft.Cdn/profiles -Tag @{"environment"="${{ inputs.environment }}"}).Name
+            $ResourceGroup = (Get-AzResource -ResourceType Microsoft.Cdn/profiles -Tag @{"environment"="${{ inputs.environment }}"}).ResourceGroupName
+            $EndpointName = (Get-AzResource -ResourceType Microsoft.Cdn/profiles/endpoints -Tag @{"repository-name"="${{ github.event.repository.name }}"} | Where-Object { $_.Tags."environment" -contains "staging" }).Name -replace ("${ProfileName}/","")
+
+            Clear-AzCdnEndpointContent -EndpointName $EndpointName -ProfileName $ProfileName -ResourceGroupName $ResourceGroup -ContentPath '/*'

--- a/.github/workflows/update-addns.yaml
+++ b/.github/workflows/update-addns.yaml
@@ -40,6 +40,7 @@ jobs:
         id: getappinfo
         uses: azure/powershell@v1.2.0
         with:
+          azPSVersion: "latest"
           inlineScript: |
             Install-Module -Name AzTable -Force
             Import-Module AzTable
@@ -78,11 +79,11 @@ jobs:
             echo "applicationIngressFqdn=$ingressFqdn" >> $env:GITHUB_ENV
             echo "healthCheckPath=$healthCheckPath" >> $env:GITHUB_ENV
             echo "aksIngress=$aksIngress" >> $env:GITHUB_ENV
-          azPSVersion: "latest"
 
       - name: Update Internal Boley DNS
         uses: azure/powershell@v1.2.0
         with:
+          azPSVersion: "latest"
           inlineScript: |
             try {
               Add-DnsServerResourceRecordCName -Name "${{ env.hostName }}" -HostNameAlias "${{ env.aksIngress}}" -ZoneName "${{ env.domainName }}" -ComputerName ${{ secrets.domainController }} 


### PR DESCRIPTION
## Description
- Default to tagged CDN endpoint if CDN inputs are not specified (but the environment input is)
- Default to tagged Azure API Management service if input is not specified
- Fix AD DNS PowerShell action missing `azPSVersion`

Testing branch: [![Purge CDN](https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/actions/workflows/purge-cdn.yml/badge.svg?branch=get-tagged-cdn-endpoint)](https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/actions/workflows/purge-cdn.yml)

## Links
N/A
