### PR TITLE
[DEVOPS-210] switch to next install/build composite actions

### DIFF
--- a/.github/workflows/next-ci.yaml
+++ b/.github/workflows/next-ci.yaml
@@ -24,7 +24,8 @@ jobs:
           token: ${{ secrets.PAT_ACTION_CI }}
           fetch-depth: 0
 
-      - uses: ./.github/actions/use-install-cache
+      - name: Use cache-next-install action
+        uses: Andrews-McMeel-Universal/cache-next-install@v1
 
       - name: Lint javascript
         run: yarn lint:js
@@ -56,7 +57,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: ./.github/actions/use-install-cache
+      - name: Use cache-next-install action
+        uses: Andrews-McMeel-Universal/cache-next-install@v1
 
       - name: Use .env cache action
         uses: Andrews-McMeel-Universal/get-envs@v1
@@ -78,7 +80,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: ./.github/actions/use-install-cache
+      - name: Use cache-next-install action
+        uses: Andrews-McMeel-Universal/cache-next-install@v1
 
       - name: Install Playwright Browsers
         run: yarn pretest:integration:ci
@@ -117,7 +120,8 @@ jobs:
           azurecredentials: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ inputs.environment }}
 
-      - uses: ./.github/actions/use-install-cache
+      - name: Use cache-next-install action
+        uses: Andrews-McMeel-Universal/cache-next-install@v1
 
       - uses: ./.github/actions/use-build-cache
 

--- a/.github/workflows/next-ci.yaml
+++ b/.github/workflows/next-ci.yaml
@@ -46,7 +46,8 @@ jobs:
           azurecredentials: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ inputs.environment }}
 
-      - uses: ./.github/actions/use-build-cache
+      - name: Use cache-next-build action
+        uses: Andrews-McMeel-Universal/cache-next-build@v1
 
   # Required status check
   unit-tests:
@@ -66,7 +67,8 @@ jobs:
           azurecredentials: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ inputs.environment }}
 
-      - uses: ./.github/actions/use-build-cache
+      - name: Use cache-next-build action
+        uses: Andrews-McMeel-Universal/cache-next-build@v1
 
       - name: Run Jest tests
         run: yarn test:unit:ci
@@ -92,7 +94,8 @@ jobs:
           azurecredentials: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ inputs.environment }}
 
-      - uses: ./.github/actions/use-build-cache
+      - name: Use cache-next-build action
+        uses: Andrews-McMeel-Universal/cache-next-build@v1
 
       - name: Run Playwright tests
         run: yarn test:integration:ci
@@ -123,7 +126,8 @@ jobs:
       - name: Use cache-next-install action
         uses: Andrews-McMeel-Universal/cache-next-install@v1
 
-      - uses: ./.github/actions/use-build-cache
+      - name: Use cache-next-build action
+        uses: Andrews-McMeel-Universal/cache-next-build@v1
 
       - name: Run Broken Link Checker
         id: link-checker-report


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-210" title="DEVOPS-210" target="_blank">DEVOPS-210</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>DevOps: Create composite actions for UI build and install steps</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://amuniversal.atlassian.net/images/icons/issuetypes/story.png" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://amuniversal.atlassian.net/issues?jql=project%20%3D%20DEVOPS%20AND%20labels%20%3D%20ServiceDesk%20ORDER%20BY%20created%20DESC" title="ServiceDesk">ServiceDesk</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [<issue>]: <description>
Where <issue> is the related Jira Issue Key.
-->

## Description

- Switch to new `cache-next-build` and `cache-next-install` composite actions in `next-ci.yaml` workflow

## Related Issues

<!-- List any related Jira issues here -->

- Jira Issue: DEVOPS-210
