### PR TITLE
[DEVOPS-XXX] Switch to new Docker-based B2C deploy-trustframework-policy action

### DIFF
--- a/.github/workflows/b2c-build-and-deploy.yaml
+++ b/.github/workflows/b2c-build-and-deploy.yaml
@@ -15,6 +15,10 @@ on:
         required: true
         type: string
         description: "Domain name of the B2C tenant."
+      azureB2CTenantId:
+        required: true
+        type: string
+        description: "Tenant Id for the B2C tenant."
       azureB2CProductUrl:
         required: false
         type: string

--- a/.github/workflows/b2c-build-and-deploy.yaml
+++ b/.github/workflows/b2c-build-and-deploy.yaml
@@ -101,14 +101,14 @@ jobs:
           yarn generate
 
       - name: Upload TrustFrameworkBase Policy
-        uses: azure-ad-b2c/deploy-trustframework-policy@v5.3
+        uses: Andrews-McMeel-Universal/deploy-trustframework-policy@v5
         with:
           folder: "./dist/custom-policies"
           files: "B2C_1A_${{ inputs.azureB2CProductId }}_SIGNINSIGNOUT_BASE.xml,B2C_1A_${{ inputs.azureB2CProductId }}_SIGNINSIGNOUT_EXTENSIONS.xml,B2C_1A_${{ inputs.azureB2CProductId }}_SIGNINSIGNOUT_POLICIES.xml,B2C_1A_${{ inputs.azureB2CProductId }}_IMPERSONATION.xml"
-          tenant: ${{ inputs.azureB2CDomain }}
+          tenantDomain: ${{ inputs.azureB2CDomain }}
+          tenantId: ${{ inputs.azureB2CTenantId }}
           clientId: ${{ secrets.azureB2CClientId }}
           clientSecret: ${{ secrets.azureB2CClientSecret }}
-          verbose: ${{ secrets.ACTIONS_STEP_DEBUG || vars.ACTIONS_STEP_DEBUG || env.ACTIONS_STEP_DEBUG || 'false' }}
 
       - name: Upload Auth Assets
         uses: azure/powershell@v1

--- a/.github/workflows/b2c-build-and-deploy.yaml
+++ b/.github/workflows/b2c-build-and-deploy.yaml
@@ -105,7 +105,7 @@ jobs:
           yarn generate
 
       - name: Upload TrustFrameworkBase Policy
-        uses: Andrews-McMeel-Universal/deploy-trustframework-policy@DEVOPS-XXX-use-new-docker-based-b2c-action
+        uses: Andrews-McMeel-Universal/deploy-trustframework-policy@v5
         with:
           folder: "./dist/custom-policies"
           files: "B2C_1A_${{ inputs.azureB2CProductId }}_SIGNINSIGNOUT_BASE.xml,B2C_1A_${{ inputs.azureB2CProductId }}_SIGNINSIGNOUT_EXTENSIONS.xml,B2C_1A_${{ inputs.azureB2CProductId }}_SIGNINSIGNOUT_POLICIES.xml,B2C_1A_${{ inputs.azureB2CProductId }}_IMPERSONATION.xml"

--- a/.github/workflows/b2c-build-and-deploy.yaml
+++ b/.github/workflows/b2c-build-and-deploy.yaml
@@ -101,7 +101,7 @@ jobs:
           yarn generate
 
       - name: Upload TrustFrameworkBase Policy
-        uses: Andrews-McMeel-Universal/deploy-trustframework-policy@v5
+        uses: Andrews-McMeel-Universal/deploy-trustframework-policy@DEVOPS-XXX-use-new-docker-based-b2c-action
         with:
           folder: "./dist/custom-policies"
           files: "B2C_1A_${{ inputs.azureB2CProductId }}_SIGNINSIGNOUT_BASE.xml,B2C_1A_${{ inputs.azureB2CProductId }}_SIGNINSIGNOUT_EXTENSIONS.xml,B2C_1A_${{ inputs.azureB2CProductId }}_SIGNINSIGNOUT_POLICIES.xml,B2C_1A_${{ inputs.azureB2CProductId }}_IMPERSONATION.xml"


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [<issue>]: <description>
Where <issue> is the related Jira Issue Key.
-->

## Description

- Switch to new Docker-based deploy-trustframework-policy action after abandoning the old/deprecated-ish action that does not return error messages when failing.

## Related Issues

<!-- List any related Jira issues here -->

- Jira Issue: N/A
