### PR TITLE
[DEVOPS-XXX] Use new v6 version of deploy B2C policy action

### DIFF
--- a/.github/workflows/b2c-build-and-deploy.yaml
+++ b/.github/workflows/b2c-build-and-deploy.yaml
@@ -87,10 +87,10 @@ jobs:
         with:
           folder: "./dist/custom-policies/"
           files: "B2C_1A_${{ env.AZURE_B2C_PRODUCT_ID }}_SIGNINSIGNOUT_BASE.xml,B2C_1A_${{ env.AZURE_B2C_PRODUCT_ID }}_SIGNINSIGNOUT_EXTENSIONS.xml,B2C_1A_${{ env.AZURE_B2C_PRODUCT_ID }}_SIGNINSIGNOUT_POLICIES.xml,B2C_1A_${{ env.AZURE_B2C_PRODUCT_ID }}_IMPERSONATION.xml"
-          tenantDomain: "${{ env.AZURE_B2C_DOMAIN }}"
-          tenantId: "${{ env.AZURE_B2C_TENANT_ID }}"
-          clientId: "${{ env.AZURE_B2C_CLIENT_ID }}"
-          clientSecret: "${{ env.AZURE_B2C_CLIENT_SECRET }}"
+          tenantDomain: ${{ env.AZURE_B2C_DOMAIN }}
+          tenantId: ${{ env.AZURE_B2C_TENANT_ID }}
+          clientId: ${{ env.AZURE_B2C_CLIENT_ID }}
+          clientSecret: ${{ env.AZURE_B2C_CLIENT_SECRET }}
 
       - name: Upload Auth Assets
         uses: azure/powershell@v1

--- a/.github/workflows/b2c-build-and-deploy.yaml
+++ b/.github/workflows/b2c-build-and-deploy.yaml
@@ -23,10 +23,6 @@ on:
         required: false
         type: string
         description: "URL of the B2C Product."
-      azureB2CProductId:
-        required: true
-        type: string
-        description: "ID of the B2C product."
     secrets:
       azureCredentials:
         required: true
@@ -87,14 +83,14 @@ jobs:
           yarn generate
 
       - name: Upload TrustFrameworkBase Policy
-        uses: Andrews-McMeel-Universal/deploy-trustframework-policy@v5
+        uses: Andrews-McMeel-Universal/deploy-trustframework-policy@devops/DEVOPS-XXX/convert-to-composite-action
         with:
           folder: "./dist/custom-policies"
-          files: "B2C_1A_${{ inputs.azureB2CProductId }}_SIGNINSIGNOUT_BASE.xml,B2C_1A_${{ inputs.azureB2CProductId }}_SIGNINSIGNOUT_EXTENSIONS.xml,B2C_1A_${{ inputs.azureB2CProductId }}_SIGNINSIGNOUT_POLICIES.xml,B2C_1A_${{ inputs.azureB2CProductId }}_IMPERSONATION.xml"
-          tenantDomain: ${{ inputs.azureB2CDomain }}
-          tenantId: ${{ inputs.azureB2CTenantId }}
-          clientId: ${{ secrets.azureB2CClientId }}
-          clientSecret: ${{ secrets.azureB2CClientSecret }}
+          files: "B2C_1A_${{ env.AZURE_B2C_PRODUCT_ID }}_SIGNINSIGNOUT_BASE.xml,B2C_1A_${{ env.AZURE_B2C_PRODUCT_ID }}_SIGNINSIGNOUT_EXTENSIONS.xml,B2C_1A_${{ env.AZURE_B2C_PRODUCT_ID }}_SIGNINSIGNOUT_POLICIES.xml,B2C_1A_${{ env.AZURE_B2C_PRODUCT_ID }}_IMPERSONATION.xml"
+          tenantDomain: "${{ env.AZURE_B2C_DOMAIN }}"
+          tenantId: "${{ env.AZURE_B2C_TENANT_ID }}"
+          clientId: "${{ env.AZURE_B2C_CLIENT_ID }}"
+          clientSecret: "${{ env.AZURE_B2C_CLIENT_SECRET }}"
 
       - name: Upload Auth Assets
         uses: azure/powershell@v1

--- a/.github/workflows/b2c-build-and-deploy.yaml
+++ b/.github/workflows/b2c-build-and-deploy.yaml
@@ -85,7 +85,7 @@ jobs:
       - name: Upload TrustFrameworkBase Policy
         uses: Andrews-McMeel-Universal/deploy-trustframework-policy@devops/DEVOPS-XXX/convert-to-composite-action
         with:
-          folder: "./dist/custom-policies"
+          folder: "./dist/custom-policies/"
           files: "B2C_1A_${{ env.AZURE_B2C_PRODUCT_ID }}_SIGNINSIGNOUT_BASE.xml,B2C_1A_${{ env.AZURE_B2C_PRODUCT_ID }}_SIGNINSIGNOUT_EXTENSIONS.xml,B2C_1A_${{ env.AZURE_B2C_PRODUCT_ID }}_SIGNINSIGNOUT_POLICIES.xml,B2C_1A_${{ env.AZURE_B2C_PRODUCT_ID }}_IMPERSONATION.xml"
           tenantDomain: "${{ env.AZURE_B2C_DOMAIN }}"
           tenantId: "${{ env.AZURE_B2C_TENANT_ID }}"

--- a/.github/workflows/b2c-build-and-deploy.yaml
+++ b/.github/workflows/b2c-build-and-deploy.yaml
@@ -86,7 +86,7 @@ jobs:
         uses: Andrews-McMeel-Universal/deploy-trustframework-policy@v6
         with:
           folder: "./dist/custom-policies/"
-          files: "B2C_1A_${{ env.AZURE_B2C_PRODUCT_ID }}_SIGNINSIGNOUT_BASE.xml,B2C_1A_${{ env.AZURE_B2C_PRODUCT_ID }}_SIGNINSIGNOUT_EXTENSIONS.xml,B2C_1A_${{ env.AZURE_B2C_PRODUCT_ID }}_SIGNINSIGNOUT_POLICIES.xml,B2C_1A_${{ env.AZURE_B2C_PRODUCT_ID }}_IMPERSONATION.xml"
+          files: "B2C_1A_${{ env.AZURE_B2C_PRODUCT_ID }}_SIGNINSIGNOUT_BASE.xml,B2C_1A_${{ env.AZURE_B2C_PRODUCT_ID }}_SIGNINSIGNOUT_EXTENSIONS.xml,B2C_1A_${{ env.AZURE_B2C_PRODUCT_ID }}_SIGNINSIGNOUT_POLICIES.xml,B2C_1A_${{ env.AZURE_B2C_PRODUCT_ID }}_IMPERSONATION.xml,B2C_1A_${{ env.AZURE_B2C_PRODUCT_ID }}_SIGNINSIGNOUT_IMPERSONATION.xml"
           tenantDomain: ${{ env.AZURE_B2C_DOMAIN }}
           tenantId: ${{ env.AZURE_B2C_TENANT_ID }}
           clientId: ${{ env.AZURE_B2C_CLIENT_ID }}

--- a/.github/workflows/b2c-build-and-deploy.yaml
+++ b/.github/workflows/b2c-build-and-deploy.yaml
@@ -83,7 +83,7 @@ jobs:
           yarn generate
 
       - name: Upload TrustFrameworkBase Policy
-        uses: Andrews-McMeel-Universal/deploy-trustframework-policy@devops/DEVOPS-XXX/convert-to-composite-action
+        uses: Andrews-McMeel-Universal/deploy-trustframework-policy@v6
         with:
           folder: "./dist/custom-policies/"
           files: "B2C_1A_${{ env.AZURE_B2C_PRODUCT_ID }}_SIGNINSIGNOUT_BASE.xml,B2C_1A_${{ env.AZURE_B2C_PRODUCT_ID }}_SIGNINSIGNOUT_EXTENSIONS.xml,B2C_1A_${{ env.AZURE_B2C_PRODUCT_ID }}_SIGNINSIGNOUT_POLICIES.xml,B2C_1A_${{ env.AZURE_B2C_PRODUCT_ID }}_IMPERSONATION.xml"


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [<issue>]: <description>
Where <issue> is the related Jira Issue Key.
-->

## Description

- Use new v6 version of deploy B2C policy action
- Use `${{ env.[VAR] }}` variable references
- Remove deprecated `azureB2CProductId` input

## Related Issues

<!-- List any related Jira issues here -->

- Jira Issue: N/A
- Testing environment: [![Development B2C Deployment](https://github.com/Andrews-McMeel-Universal/gocomics_b2c/actions/workflows/deploy-development.yml/badge.svg?branch=devops%2FDEVOPS-XXX%2Fconvert-to-composite-action)](https://github.com/Andrews-McMeel-Universal/gocomics_b2c/actions/workflows/deploy-development.yml)
