### PR TITLE
[DEVOPS-253] Resolve .NET Application CI dependency caching issues

### DIFF
--- a/.github/workflows/dotnet-ci.yaml
+++ b/.github/workflows/dotnet-ci.yaml
@@ -56,6 +56,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.nuget/packages
             **/project.assets.json
+            **/obj/
           # Look to see if there is a cache hit for the corresponding requirements file
           key: install-${{ hashFiles('**/*.csproj','**/project.assets.json') }}
 


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-253" title="DEVOPS-253" target="_blank">DEVOPS-253</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Resolve GoComics Store .NET Application CI dependency failures</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://amuniversal.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [<issue>]: <description>
Where <issue> is the related Jira Issue Key.
-->

## Description

- [Added `obj` directories to install-cache step in dotnet-ci.yaml](https://github.com/Andrews-McMeel-Universal/reusable_workflows/commit/ae8c071f807958c3814cb276e95343e22d3b7deb)

## Related Issues

<!-- List any related Jira issues here -->

- Jira Issue: DEVOPS-253