### PR TITLE
[DEVOPS-265] Add environmentCharts input

### DIFF
--- a/.github/workflows/bump-versions.yaml
+++ b/.github/workflows/bump-versions.yaml
@@ -7,6 +7,11 @@ on:
         required: true
         type: string
         description: Type of release
+      environmentCharts:
+        required: false
+        type: boolean
+        description: Set to true if the repository has separate Helm chart directories for each environment
+        default: false
     secrets:
       PAT_ACTION_CI:
         required: false
@@ -24,10 +29,19 @@ jobs:
         uses: thebritican/fetch-latest-release@v2.0.0
 
       - name: Get Chart.yaml appVersion
+        if: inputs.environmentCharts == false
         id: chartyaml
         uses: rmeneely/get-yaml-value@v1
         with:
           infile: deployments/charts/Chart.yaml
+          varlist: appVersion
+
+      - name: Get Environment Chart.yaml appVersion
+        if: inputs.environmentCharts == true
+        id: environmentchartyaml
+        uses: rmeneely/get-yaml-value@v1
+        with:
+          infile: deployments/production-charts/Chart.yaml
           varlist: appVersion
 
       - name: Check if package.json exists
@@ -48,7 +62,7 @@ jobs:
         shell: pwsh
         run: |
           [Version]$a = "${{ steps.packagejson.outputs.prop || '0.0.0' }}"
-          [Version]$b = "${{ steps.chartyaml.outputs.values || '0.0.0' }}"
+          [Version]$b = "${{ steps.environmentchartyaml.outputs.values || steps.chartyaml.outputs.values || '0.0.0' }}"
           [Version]$c = "${{ steps.latestrelease.outputs.tag_name || '0.0.0' }}"
 
           $versions = [array]($a,$b,$c)


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-265" title="DEVOPS-265" target="_blank">DEVOPS-265</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Update Bump versions workflow to account for environment-based Helm charts</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://amuniversal.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [<issue>]: <description>
Where <issue> is the related Jira Issue Key.
-->

## Description

- Adding `environmentCharts` input to bump versions workflow to account for repositories that have environment-based Helm charts

## Related Issues

<!-- List any related Jira issues here -->

- Test environment: [![Bump Version](https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/actions/workflows/bump-versions.yml/badge.svg)](https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/actions/workflows/bump-versions.yml)
- Jira issue: DEVOPS-265
- Test environment PR: https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/pull/66
