### PR TITLE
[DEVOPS-272] Switch back to default Azure login action to avoid caching issues

### DIFF
--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -438,11 +438,10 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
     steps:
-      - name: Login to Azure
-        uses: Andrews-McMeel-Universal/cache-azure-login@v1
+      - name: Login via Az module
+        uses: azure/login@v1
         with:
-          azureCredentials: "${{ secrets.azureCredentials }}"
-          enable-AzPsSession: false
+          creds: "${{ secrets.azureCredentials }}"
 
       - name: Create or Update Public DNS Record
         run: |

--- a/.github/workflows/azfunction-deploy.yaml
+++ b/.github/workflows/azfunction-deploy.yaml
@@ -73,10 +73,10 @@ jobs:
           dotnet build --configuration Release --output ./output
           popd
 
-      - name: Login to Azure
-        uses: Andrews-McMeel-Universal/cache-azure-login@v1
+      - name: Login via Az module
+        uses: azure/login@v1
         with:
-          azureCredentials: "${{ secrets.AZURE_CREDENTIALS }}"
+          creds: "${{ secrets.AZURE_CREDENTIALS }}"
 
       - name: Whitelist Boley IPs
         uses: azure/CLI@v1

--- a/.github/workflows/b2c-build-and-deploy.yaml
+++ b/.github/workflows/b2c-build-and-deploy.yaml
@@ -62,11 +62,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Login to Azure
-        uses: Andrews-McMeel-Universal/cache-azure-login@v1
-        with:
-          azureCredentials: "${{ secrets.azureCredentials }}"
-
       - name: Generate .env file from Azure Key Vaults
         uses: Andrews-McMeel-Universal/get-envs@v1
         with:

--- a/.github/workflows/clear-azure-redis-cache.yaml
+++ b/.github/workflows/clear-azure-redis-cache.yaml
@@ -27,10 +27,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Login to Azure
-        uses: Andrews-McMeel-Universal/cache-azure-login@v1
+      - name: Login via Az module
+        uses: azure/login@v1
         with:
-          azureCredentials: "${{ secrets.azureCredentials }}"
+          creds: "${{ secrets.azureCredentials }}"
+          enable-AzPSSession: true
 
       - name: Install Dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1

--- a/.github/workflows/next-ci.yaml
+++ b/.github/workflows/next-ci.yaml
@@ -40,11 +40,6 @@ jobs:
           commit_user_email: amu_deploy@amuniversal.com
           commit_message: "[Formatter] Apply prettier changes"
 
-      - name: Login to Azure
-        uses: Andrews-McMeel-Universal/cache-azure-login@v1
-        with:
-          azureCredentials: "${{ secrets.AZURE_CREDENTIALS }}"
-
       - name: Use .env cache action
         uses: Andrews-McMeel-Universal/get-envs@v1
         with:
@@ -66,11 +61,6 @@ jobs:
       - name: Use cache-next-install action
         uses: Andrews-McMeel-Universal/cache-next-install@v1
 
-      - name: Login to Azure
-        uses: Andrews-McMeel-Universal/cache-azure-login@v1
-        with:
-          azureCredentials: "${{ secrets.AZURE_CREDENTIALS }}"
-
       - name: Use .env cache action
         uses: Andrews-McMeel-Universal/get-envs@v1
         with:
@@ -83,7 +73,6 @@ jobs:
       - name: Run Jest tests
         run: yarn test:unit:ci
 
-  # Required status check
   integration-tests:
     name: Integration Tests
     needs: [build]
@@ -97,11 +86,6 @@ jobs:
 
       - name: Install Playwright Browsers
         run: yarn pretest:integration:ci
-
-      - name: Login to Azure
-        uses: Andrews-McMeel-Universal/cache-azure-login@v1
-        with:
-          azureCredentials: "${{ secrets.AZURE_CREDENTIALS }}"
 
       - name: Use .env cache action
         uses: Andrews-McMeel-Universal/get-envs@v1
@@ -131,11 +115,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Login to Azure
-        uses: Andrews-McMeel-Universal/cache-azure-login@v1
-        with:
-          azureCredentials: "${{ secrets.AZURE_CREDENTIALS }}"
 
       - name: Use .env cache action
         uses: Andrews-McMeel-Universal/get-envs@v1

--- a/.github/workflows/purge-cdn.yaml
+++ b/.github/workflows/purge-cdn.yaml
@@ -38,10 +38,11 @@ jobs:
               exit 1
             }
 
-      - name: Login to Azure
-        uses: Andrews-McMeel-Universal/cache-azure-login@v1
+      - name: Login via Az module
+        uses: azure/login@v1
         with:
-          azureCredentials: "${{ secrets.azureCredentials }}"
+          creds: "${{ secrets.azureCredentials }}"
+          enable-AzPSSession: true
 
       - name: Purge CDN cache
         uses: azure/powershell@v1

--- a/.github/workflows/ruby-ci.yaml
+++ b/.github/workflows/ruby-ci.yaml
@@ -37,11 +37,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Login to Azure
-        uses: Andrews-McMeel-Universal/cache-azure-login@v1
-        with:
-          azureCredentials: "${{ secrets.AZURE_CREDENTIALS }}"
-
       - name: Use .env cache action
         uses: Andrews-McMeel-Universal/get-envs@v1
         with:

--- a/.github/workflows/ui-ci.yaml
+++ b/.github/workflows/ui-ci.yaml
@@ -40,11 +40,6 @@ jobs:
           commit_user_email: amu_deploy@amuniversal.com
           commit_message: "[Formatter] Apply prettier changes"
 
-      - name: Login to Azure
-        uses: Andrews-McMeel-Universal/cache-azure-login@v1
-        with:
-          azureCredentials: "${{ secrets.AZURE_CREDENTIALS }}"
-
       - name: Use .env cache action
         uses: Andrews-McMeel-Universal/get-envs@v1
         with:
@@ -64,11 +59,6 @@ jobs:
 
       - name: Use cache-yarn-install action
         uses: Andrews-McMeel-Universal/cache-yarn-install@v1
-
-      - name: Login to Azure
-        uses: Andrews-McMeel-Universal/cache-azure-login@v1
-        with:
-          azureCredentials: "${{ secrets.AZURE_CREDENTIALS }}"
 
       - name: Use .env cache action
         uses: Andrews-McMeel-Universal/get-envs@v1
@@ -95,11 +85,6 @@ jobs:
 
       - name: Install Playwright Browsers
         run: yarn pretest:integration:ci
-
-      - name: Login to Azure
-        uses: Andrews-McMeel-Universal/cache-azure-login@v1
-        with:
-          azureCredentials: "${{ secrets.AZURE_CREDENTIALS }}"
 
       - name: Use .env cache action
         uses: Andrews-McMeel-Universal/get-envs@v1
@@ -129,11 +114,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Login to Azure
-        uses: Andrews-McMeel-Universal/cache-azure-login@v1
-        with:
-          azureCredentials: "${{ secrets.AZURE_CREDENTIALS }}"
 
       - name: Use .env cache action
         uses: Andrews-McMeel-Universal/get-envs@v1

--- a/.github/workflows/update-azureapimanagement.yaml
+++ b/.github/workflows/update-azureapimanagement.yaml
@@ -73,10 +73,12 @@ jobs:
       azurePassword: ${{ secrets.azurePassword }}
       azureSubscription: ${{ secrets.azureSubscription }}
     steps:
-      - name: Login to Azure
-        uses: Andrews-McMeel-Universal/cache-azure-login@v1
+      - name: Login via Az module
+        if: ${{ env.azureCredentials }}
+        uses: azure/login@v1
         with:
-          azureCredentials: "${{ secrets.azureCredentials }}"
+          creds: "${{ secrets.azureCredentials }}"
+          enable-AzPSSession: true
 
       - name: Login via PowerShell
         if: ${{ inputs.azureUser && env.azurePassword && env.azureSubscription }}

--- a/.github/workflows/update-game-config.yaml
+++ b/.github/workflows/update-game-config.yaml
@@ -19,11 +19,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Login to Azure
-        uses: Andrews-McMeel-Universal/cache-azure-login@v1
-        with:
-          azureCredentials: "${{ secrets.AZURE_CREDENTIALS }}"
-
       - name: Generate .env file from Azure Key Vaults
         uses: Andrews-McMeel-Universal/get-envs@v1
         with:


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-272" title="DEVOPS-272" target="_blank">DEVOPS-272</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Switch back to the default Azure Login GitHub action in the reusable workflows</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://amuniversal.atlassian.net/images/icons/issuetypes/story.png" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [<issue>]: <description>
Where <issue> is the related Jira Issue Key.
-->

## Description

- Switch back to default azure login action where applicable. In other cases, just remove it if `get-envs` action is run since it already logs in to Azure.

## Related Issues

<!-- List any related Jira issues here -->

- Jira Issue: DEVOPS-272
