### PR TITLE
[DEVOPS-280] Add runYarnInstall input to Simple Lint workflow

### DIFF
--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -8,6 +8,9 @@ on:
       runPrettier:
         default: true
         type: boolean
+      runYarnInstall:
+        default: false
+        type: boolean
     secrets:
       PAT_ACTION_CI:
         required: true
@@ -23,9 +26,12 @@ jobs:
         with:
           token: ${{ secrets.PAT_ACTION_CI }}
 
+      - name: Use cache-next-install action
+        if: ${{ inputs.runYarnInstall }}
+        uses: Andrews-McMeel-Universal/cache-next-install@v1
+
       - uses: actionsx/prettier@v3
         with:
-          # prettier CLI arguments.
           args: --write .
 
       - uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-280" title="DEVOPS-280" target="_blank">DEVOPS-280</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Resolve failed prettier dependabot PR checks in TPS UI</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://amuniversal.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [<issue>]: <description>
Where <issue> is the related Jira Issue Key.
-->

## Description

- Add `runYarnInstall` input to Simple Lint workflow that runs `yarn install` before running prettier

## Related Issues

<!-- List any related Jira issues here -->

- Jira Issue: DEVOPS-280
