### PR TITLE
[DEVOPS-279] Changed autoApprove and autoMerge inputs to arrays

### DIFF
--- a/.github/workflows/dependabot-automations.yaml
+++ b/.github/workflows/dependabot-automations.yaml
@@ -6,17 +6,19 @@ on:
   workflow_call:
     inputs:
       autoApprove:
-        default: false
-        type: boolean
+        default: "false"
+        description: Array of version update to automatically approve (for ex. '["version-update:semver-major", "version-update:semver-minor"]')
+        type: string
       autoMerge:
-        default: false
-        type: boolean
+        default: "false"
+        description: Array of version update to automatically merge in (for ex. '["version-update:semver-major", "version-update:semver-minor"]')
+        type: string
 
 jobs:
   dependabot-automations:
     name: Dependabot Automations
     runs-on: ubuntu-latest
-    if: ${{ inputs.autoApprove || inputs.autoMerge }}
+    if: ${{ inputs.autoApprove != 'false' || inputs.autoMerge != 'false' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -29,14 +31,15 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Approve PR
-        uses: hmarr/auto-approve-action@v3.2.1
-        if: ${{ inputs.autoApprove }}
+        if: ${{ contains(fromJson(inputs.autoApprove), steps.dependabot-metadata.outputs.update-type) }}
+        uses: hmarr/auto-approve-action@v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Enable auto-merge
-        if: ${{ inputs.autoMerge && steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major' }}
-        run: gh pr merge --auto --squash "$PR_URL"
+        if: ${{ contains(fromJson(inputs.autoMerge), steps.dependabot-metadata.outputs.update-type) }}
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          gh pr merge --auto --squash "${PR_URL}"


### PR DESCRIPTION
<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-279" title="DEVOPS-279" target="_blank">DEVOPS-279</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Rework Dependabot Automations Reusable Workflow to add more auto-merge/auto-approve options</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://amuniversal.atlassian.net/images/icons/issuetypes/story.png" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Changed `autoApprove` and `autoMerge` inputs in dependabot automations workflow to be array objects that allow the user to choose which type of updates they would like to auto-approve and auto-merge.

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-279
- Testing environment: Dependabot created the PR listed below with the `autoApprove` and `autoMerge` options set to false. I made the following commit and had dependabot rebase the PR. Dependabot rebasing the PR caused the dependabot automations workflow to be run again with the updated `autoApprove` input that included `"version-update:semver-major"`, which caused it automatically approve the PR.
  - Commit: https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/commit/acbf77cb0a8988d39b7472767c35f0f49e05a369
  - Dependabot PR: https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/pull/71
