### PR TITLE
[DEVOPS-269] Lint PR for Jira issue key before Jira linter

### DIFF
--- a/.github/workflows/jira-lint.yaml
+++ b/.github/workflows/jira-lint.yaml
@@ -17,14 +17,35 @@ on:
       JIRA_TOKEN:
         required: true
 
+env:
+  githubPrBranch: ${{ github.head_ref }}
+  githubPrTitle: ${{ github.event.pull_request.title }}
+
 jobs:
   jira-lint:
     name: Run Jira Lint
     runs-on: ubuntu-latest
     steps:
-      - name: Check for missing Jira ID comment
-        uses: peter-evans/find-comment@v2
+      - name: Retrieve Jira issue key from PR
+        id: jira-ticket
+        run: |
+          PR_BRANCH=$(echo "${{ env.githubPrBranch }}" | grep -Eo "\b[A-Z][A-Z0-9_]+-[1-9][0-9]*")
+          PR_TITLE=$(echo "${{ env.githubPrTitle }}" | grep -Eo "\b[A-Z][A-Z0-9_]+-[1-9][0-9]*")
+
+          for var in ${PR_BRANCH} ${PR_TITLE}; do JIRA_TICKET_ID=$(echo $var | grep -E ".") && break ; done
+
+          if [ -z "${JIRA_TICKET_ID}" ]; then
+            if [ "${{ inputs.fail-on-error }}" = "true" ]; then
+                echo "::error A Jira issue key is missing from your branch name and pull request title. Please confirm it is linked properly in the pull request."
+                exit 1
+            else
+                echo "::warning A Jira issue key is missing from your branch name and pull request title. Please confirm it is linked properly in the pull request."
+            fi
+          fi
+
+      - name: Check if missing Jira issue key comment exists
         id: comment
+        uses: peter-evans/find-comment@v2
         with:
           issue-number: ${{ github.event.number }}
           body-includes: A JIRA Issue ID is missing from your branch name!


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-269" title="DEVOPS-269" target="_blank">DEVOPS-269</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Research alternatives or fixes for Jira linter GitHub action</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Improvement" src="https://amuniversal.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10310?size=medium" />
        Improvement
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Lint PR for Jira issue key before Jira linter runs

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-269
