### PR TITLE
[DEVOPS-284] Add support for deploying to default Kubernetes namespace

### DIFF
--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -383,6 +383,7 @@ jobs:
           resource-group: ${{ inputs.clusterResourceGroup }}
 
       - name: Switch to ${{ inputs.environment }} Namespace
+        if: ${{ ! inputs.environmentClusterIngress }}
         run: kubectl config set-context --current --namespace="${{ inputs.environment }}"
 
       - name: Apply configMap if it exists

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -86,7 +86,7 @@ on:
         type: string
         description: "Add the environment name to the front of the hostname (for DNS)"
         default: "true"
-      environmentClusterIngress:
+      environmentNamespace:
         required: false
         type: boolean
         description: "Enable/Disable adding environment in AKS cluster ingress DNS record"
@@ -389,7 +389,7 @@ jobs:
       - name: Switch Kubernetes Namespace
         shell: pwsh
         run: |
-          if ( "${{ inputs.environmentClusterIngress }}" -eq "true") {
+          if ( "${{ inputs.environmentNamespace }}" -eq "true") {
             kubectl config set-context --current --namespace="${{ inputs.environment }}"
             Write-Output  "namespace=${{ inputs.environment }}" >> $env:GITHUB_ENV
           }
@@ -458,7 +458,7 @@ jobs:
       - name: Create or Update Public DNS Record
         id: dns
         run: |
-          if [ "${{ inputs.environmentClusterIngress }}" == "true" ]; then
+          if [ "${{ inputs.environmentNamespace }}" == "true" ]; then
             INGRESS="${{ secrets.azureClusterName }}-${{ inputs.environment }}"
           else
             INGRESS="${{ secrets.azureClusterName }}"

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -463,8 +463,8 @@ jobs:
           else
             INGRESS="${{ secrets.azureClusterName }}"
           fi
-          AKS_INGRESS="${INGRESS}-ingress.centralus.cloudapp.azure.com"
-          az network dns record-set cname set-record --resource-group ${{ inputs.dnsResourceGroup }} --zone-name "${{ needs.build.outputs.domainName }}" --record-set-name "${{ needs.build.outputs.hostName }}" --cname "${AKS_INGRESS}" --ttl 3600
+          AKS_INGRESS="${INGRESS}-ingress.centralus.cloudapp.azure.com."
+          az network dns record-set cname set-record --resource-group "${{ inputs.dnsResourceGroup }}" --zone-name "${{ needs.build.outputs.domainName }}" --record-set-name "${{ needs.build.outputs.hostName }}" --cname "${AKS_INGRESS}" --ttl 3600
 
           echo "aksIngress=${AKS_INGRESS}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -447,10 +447,10 @@ jobs:
         uses: azure/powershell@v1
         with:
           inlineScript: |
-            if ("${{ inputs.environmentClusterIngress }}") {
+            if ("${{ inputs.environmentClusterIngress }}" -eq "true") {
                 $ClusterIngress = "${{ secrets.azureClusterName }}-${{ inputs.environment }}"
             }
-            elseif (!("${{ inputs.environmentClusterIngress }}")) {
+            elseif ("${{ inputs.environmentClusterIngress }}" -eq "false") {
                 $ClusterIngress = "${{ secrets.azureClusterName }}"
             }
             $NewRecords = New-AzDnsRecordConfig -Cname "${ClusterIngress}-ingress.centralus.cloudapp.azure.com."

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -456,13 +456,17 @@ jobs:
           creds: "${{ secrets.azureCredentials }}"
 
       - name: Create or Update Public DNS Record
+        id: dns
         run: |
           if [ "${{ inputs.environmentClusterIngress }}" == "true" ]; then
             INGRESS="${{ secrets.azureClusterName }}-${{ inputs.environment }}"
           else
             INGRESS="${{ secrets.azureClusterName }}"
           fi
-          az network dns record-set cname set-record --resource-group ${{ inputs.dnsResourceGroup }} --zone-name "${{ needs.build.outputs.domainName }}" --record-set-name ${{ needs.build.outputs.hostName }} --cname "${INGRESS}-ingress.centralus.cloudapp.azure.com." --ttl 3600
+          AKS_INGRESS="${INGRESS}-ingress.centralus.cloudapp.azure.com"
+          az network dns record-set cname set-record --resource-group ${{ inputs.dnsResourceGroup }} --zone-name "${{ needs.build.outputs.domainName }}" --record-set-name "${{ needs.build.outputs.hostName }}" --cname "${AKS_INGRESS}" --ttl 3600
+
+          echo "aksIngress=${AKS_INGRESS}" >> $GITHUB_OUTPUT
 
       - name: Record deployment information in Azure Storage Table
         uses: LadyCailin/azure-table-storage-upload@v1.0.1
@@ -470,7 +474,7 @@ jobs:
           table_name: "${{ inputs.appInfoTableName }}"
           partition_key: "${{ inputs.repositoryName }}"
           row_key: "${{ inputs.environment }}"
-          data: "ApplicationName=${{ needs.build.outputs.appName }} Version=${{ needs.build.outputs.appVersion }} KeyVault=${{ inputs.environmentKeyVault }} HostName=${{ needs.build.outputs.hostName }} DomainName=${{ needs.build.outputs.domainName }} IngressFqdn=${{ needs.build.outputs.ingress }} HealthCheckPath=${{ needs.build.outputs.appHealthCheck }} AksIngress=${{ env.clusterIngress }}-ingress.centralus.cloudapp.azure.com. Cluster=${{ secrets.azureClusterName }} ClusterResourceGroup=${{ inputs.clusterResourceGroup }} ConfigSecret=${{needs.build.outputs.configSecret }} ConfigMap=${{ needs.build.outputs.configMap }} LastDeploy=${{ needs.build.outputs.date }}"
+          data: "ApplicationName=${{ needs.build.outputs.appName }} Version=${{ needs.build.outputs.appVersion }} KeyVault=${{ inputs.environmentKeyVault }} HostName=${{ needs.build.outputs.hostName }} DomainName=${{ needs.build.outputs.domainName }} IngressFqdn=${{ needs.build.outputs.ingress }} HealthCheckPath=${{ needs.build.outputs.appHealthCheck }} AksIngress=${{ steps.dns.outputs.aksIngress }} Cluster=${{ secrets.azureClusterName }} ClusterResourceGroup=${{ inputs.clusterResourceGroup }} ConfigSecret=${{needs.build.outputs.configSecret }} ConfigMap=${{ needs.build.outputs.configMap }} LastDeploy=${{ needs.build.outputs.date }}"
           if_exists: "replace"
           extra_args: ""
           connection_string: "AccountName=${{ inputs.storageAccountName }};AccountKey=${{ secrets.storageAccountKey }}"

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -383,7 +383,7 @@ jobs:
           resource-group: ${{ inputs.clusterResourceGroup }}
 
       - name: Switch to ${{ inputs.environment }} Namespace
-        if: ${{ ! inputs.environmentClusterIngress }}
+        if: ${{ inputs.environmentClusterIngress == 'false' }}
         run: kubectl config set-context --current --namespace="${{ inputs.environment }}"
 
       - name: Apply configMap if it exists

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -387,15 +387,14 @@ jobs:
           resource-group: ${{ inputs.clusterResourceGroup }}
 
       - name: Switch Kubernetes Namespace
-        shell: pwsh
+        id: namespace
         run: |
-          if ( "${{ inputs.environmentNamespace }}" -eq "true") {
+          if [ "${{ inputs.environmentNamespace }}" == "true" ]; then
             kubectl config set-context --current --namespace="${{ inputs.environment }}"
-            Write-Output  "namespace=${{ inputs.environment }}" >> $env:GITHUB_ENV
-          }
-          else {
-            Write-Output  "namespace=default" >> $env:GITHUB_ENV
-          }
+            echo "namespace=${{ inputs.environment }}" >> $GITHUB_OUTPUT
+          else
+            echo "namespace=default" >> $GITHUB_OUTPUT
+          fi
 
       - name: Apply configMap if it exists
         if: ${{ needs.build.outputs.configMap != null }}
@@ -436,7 +435,7 @@ jobs:
         timeout-minutes: ${{ inputs.deploymentTimeout }}
         uses: Azure/k8s-deploy@v4
         with:
-          namespace: ${{ env.namespace }}
+          namespace: ${{ steps.namespace.outputs.namespace }}
           manifests: ${{ needs.build.outputs.manifestsBundle }}
           images: |
             "${{ secrets.registryHostName }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -383,13 +383,15 @@ jobs:
           resource-group: ${{ inputs.clusterResourceGroup }}
 
       - name: Switch Kubernetes Namespace
+        shell: pwsh
         run: |
           if ( "${{ inputs.environmentClusterIngress }}" -eq "true") {
             kubectl config set-context --current --namespace="${{ inputs.environment }}"
-            echo "namespace=${{ inputs.environment }}" >> $GITHUB_ENV
-          else
-            echo "namespace=default" >> $GITHUB_ENV
-          fi
+            Write-Output  "namespace=${{ inputs.environment }}" >> $env:GITHUB_ENV
+          }
+          else {
+            Write-Output  "namespace=default" >> $env:GITHUB_ENV
+          }
 
       - name: Apply configMap if it exists
         if: ${{ needs.build.outputs.configMap != null }}
@@ -398,6 +400,7 @@ jobs:
           k8-config-file-paths: deployments/k8s/config-${{ inputs.environment }}.yaml
 
       - name: Add GitHub secrets to k8s
+        shell: pwsh
         run: |
           if (kubectl get secret | Select-String "${{ needs.build.outputs.configSecret }}") {
               kubectl delete secret "${{ needs.build.outputs.configSecret }}"

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -86,6 +86,11 @@ on:
         type: string
         description: "Add the environment name to the front of the hostname (for DNS)"
         default: "true"
+      environmentClusterIngress:
+        required: false
+        type: boolean
+        description: "Enable/Disable adding environment in AKS cluster ingress DNS record"
+        default: true
     secrets:
       azureClusterName:
         required: true
@@ -442,9 +447,17 @@ jobs:
         uses: azure/powershell@v1
         with:
           inlineScript: |
-            $NewRecords = New-AzDnsRecordConfig -Cname "${{ secrets.azureClusterName }}-${{ inputs.environment }}-ingress.centralus.cloudapp.azure.com."
+            if ("${{ inputs.environmentClusterIngress }}") {
+                $ClusterIngress = ${{ secrets.azureClusterName }}-${{ inputs.environment }}"
+            }
+            elseif (!("${{ inputs.environmentClusterIngress }}")) {
+                $ClusterIngress = ${{ secrets.azureClusterName }}"
+            }
+            $NewRecords = New-AzDnsRecordConfig -Cname "${ClusterIngress}-ingress.centralus.cloudapp.azure.com."
 
             New-AzDnsRecordSet -Name "${{ needs.build.outputs.hostName }}" -RecordType CNAME -ZoneName "${{ needs.build.outputs.domainName }}" -ResourceGroupName ${{ inputs.dnsResourceGroup }} -Ttl 3600 -DnsRecords $NewRecords -Overwrite;
+
+            Write-Output  "clusterIngress=$ClusterIngress" >> $env:GITHUB_ENV
           azPSVersion: "latest"
 
       - name: Record deployment information in Azure Storage Table
@@ -453,7 +466,7 @@ jobs:
           table_name: "${{ inputs.appInfoTableName }}"
           partition_key: "${{ inputs.repositoryName }}"
           row_key: "${{ inputs.environment }}"
-          data: "ApplicationName=${{ needs.build.outputs.appName }} Version=${{ needs.build.outputs.appVersion }} KeyVault=${{ inputs.environmentKeyVault }} HostName=${{ needs.build.outputs.hostName }} DomainName=${{ needs.build.outputs.domainName }} IngressFqdn=${{ needs.build.outputs.ingress }} HealthCheckPath=${{ needs.build.outputs.appHealthCheck }} AksIngress=${{ secrets.azureClusterName }}-${{ inputs.environment }}-ingress.centralus.cloudapp.azure.com. Cluster=${{ secrets.azureClusterName }} ClusterResourceGroup=${{ inputs.clusterResourceGroup }} ConfigSecret=${{needs.build.outputs.configSecret }} ConfigMap=${{ needs.build.outputs.configMap }} LastDeploy=${{ needs.build.outputs.date }}"
+          data: "ApplicationName=${{ needs.build.outputs.appName }} Version=${{ needs.build.outputs.appVersion }} KeyVault=${{ inputs.environmentKeyVault }} HostName=${{ needs.build.outputs.hostName }} DomainName=${{ needs.build.outputs.domainName }} IngressFqdn=${{ needs.build.outputs.ingress }} HealthCheckPath=${{ needs.build.outputs.appHealthCheck }} AksIngress=${{ env.clusterIngress }}-ingress.centralus.cloudapp.azure.com. Cluster=${{ secrets.azureClusterName }} ClusterResourceGroup=${{ inputs.clusterResourceGroup }} ConfigSecret=${{needs.build.outputs.configSecret }} ConfigMap=${{ needs.build.outputs.configMap }} LastDeploy=${{ needs.build.outputs.date }}"
           if_exists: "replace"
           extra_args: ""
           connection_string: "AccountName=${{ inputs.storageAccountName }};AccountKey=${{ secrets.storageAccountKey }}"

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -382,9 +382,14 @@ jobs:
           cluster-name: ${{ secrets.azureClusterName }}
           resource-group: ${{ inputs.clusterResourceGroup }}
 
-      - name: Switch to ${{ inputs.environment }} Namespace
-        if: ${{ inputs.environmentClusterIngress == 'false' }}
-        run: kubectl config set-context --current --namespace="${{ inputs.environment }}"
+      - name: Switch Kubernetes Namespace
+        run: |
+          if ( "${{ inputs.environmentClusterIngress }}" -eq "true") {
+            kubectl config set-context --current --namespace="${{ inputs.environment }}"
+            echo "namespace=${{ inputs.environment }}" >> $GITHUB_ENV
+          else
+            echo "namespace=default" >> $GITHUB_ENV
+          fi
 
       - name: Apply configMap if it exists
         if: ${{ needs.build.outputs.configMap != null }}
@@ -393,7 +398,6 @@ jobs:
           k8-config-file-paths: deployments/k8s/config-${{ inputs.environment }}.yaml
 
       - name: Add GitHub secrets to k8s
-        shell: pwsh
         run: |
           if (kubectl get secret | Select-String "${{ needs.build.outputs.configSecret }}") {
               kubectl delete secret "${{ needs.build.outputs.configSecret }}"
@@ -425,7 +429,7 @@ jobs:
         timeout-minutes: ${{ inputs.deploymentTimeout }}
         uses: Azure/k8s-deploy@v4
         with:
-          namespace: ${{ inputs.environment }}
+          namespace: ${{ env.namespace }}
           manifests: ${{ needs.build.outputs.manifestsBundle }}
           images: |
             "${{ secrets.registryHostName }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -448,10 +448,10 @@ jobs:
         with:
           inlineScript: |
             if ("${{ inputs.environmentClusterIngress }}") {
-                $ClusterIngress = ${{ secrets.azureClusterName }}-${{ inputs.environment }}"
+                $ClusterIngress = "${{ secrets.azureClusterName }}-${{ inputs.environment }}"
             }
             elseif (!("${{ inputs.environmentClusterIngress }}")) {
-                $ClusterIngress = ${{ secrets.azureClusterName }}"
+                $ClusterIngress = "${{ secrets.azureClusterName }}"
             }
             $NewRecords = New-AzDnsRecordConfig -Cname "${ClusterIngress}-ingress.centralus.cloudapp.azure.com."
 


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-284" title="DEVOPS-284" target="_blank">DEVOPS-284</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Update AKS deploy workflow to account for new AKS clusters</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://amuniversal.atlassian.net/images/icons/issuetypes/story.png" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Development Env</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Add support for deploying to default Kubernetes namespace by adding the `environmentNamespace` input.

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-284
- Testing environment: [![Reusable Workflow Test](https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/actions/workflows/aks-development.yml/badge.svg?branch=story%2FDEVOPS-284%2Fadd-environment-cluster-ingress-input)](https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/actions/workflows/aks-development.yml)
