### PR TITLE
[DEVOPS-294] Add enableNginxIngressLogging input to AKS deploy workflow

### DIFF
--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -91,6 +91,11 @@ on:
         type: boolean
         description: "Enable/Disable adding environment in AKS cluster ingress DNS record"
         default: true
+      enableNginxAccessLogging:
+        required: false
+        type: boolean
+        description: Enable access logging in Kubernetes ingress
+        default: false
     secrets:
       azureClusterName:
         required: true
@@ -334,6 +339,7 @@ jobs:
             image.tag:${{ inputs.dockerImageTag }}
             ingress.host:${{ env.ingress }}
             autoscaling.maxReplicas:${{ inputs.maximumReplicas }}
+            ingress.annotations.nginx\.ingress\.kubernetes\.io/enable-access-log=${{ inputs.enableNginxAccessLogging }}
 
       - name: Upload bake-manifests-bundle artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-294" title="DEVOPS-294" target="_blank">DEVOPS-294</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Scale down Nginx Ingress Controller logging in the AKS cluster</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://amuniversal.atlassian.net/images/icons/issuetypes/story.png" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Added `enableNginxIngressLogging` input to AKS deploy workflow to cut down on excessive Nginx controller logging in Kubernetes. Default is set to "false". In projects that we'll want access logging, we'll set the input to "true" in the deploy workflow inputs

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-294
