### PR TITLE
[DEVOPS-301] Link ephemeral deployment URL in Jira ticket after successful deployment

### DIFF
--- a/.github/workflows/ephemeral-deploy.yaml
+++ b/.github/workflows/ephemeral-deploy.yaml
@@ -52,6 +52,8 @@ on:
         required: true
       githubPAT:
         required: true
+      JIRA_TOKEN:
+        required: true
 
 env:
   githubPrBranch: ${{ github.head_ref }}
@@ -283,6 +285,43 @@ jobs:
           environmentVariables: ${{ steps.next-vars.outputs.environmentVariables }}
           ingress: external
           disableTelemetry: true
+
+  link-deployment:
+    name: Link Deployment in Jira
+    needs: [prepare,deploy]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if deployment has already been linked
+        id: check-jira-comments
+        shell: pwsh
+        run: |
+          $uri = "https://amuniversal.atlassian.net/rest/api/2/issue/${{ needs.prepare.outputs.jiraTicketId }}"
+          $username = "amu_deploy@amuniversal.com"
+          $token = "${{ secrets.JIRA_TOKEN }}"
+          $base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $username,$token)))
+          $response = Invoke-RestMethod -Headers @{Authorization=("Basic {0}" -f $base64AuthInfo)} -Uri $uri -Method Get
+          $comments = $response.fields.comment.comments
+          foreach ($comment in $comments) {
+              if ($comment.body -match "This ticket has been linked to an ephemeral deployment. The URL is: ${{ needs.deploy.outputs.hostname }}") {
+                  Write-Output "comment-found=true" >> $env:GITHUB_OUTPUT
+                  break
+              }
+          }
+
+      - name: Login to Jira
+        if: ${{ steps.check-jira-comments.outputs.comment-found != 'true' }}
+        uses: atlassian/gajira-login@v3
+        env:
+          JIRA_BASE_URL: https://amuniversal.atlassian.net
+          JIRA_USER_EMAIL: amu_deploy@amuniversal.com
+          JIRA_API_TOKEN: ${{ secrets.JIRA_TOKEN }}
+
+      - name: Link ephemeral deployment in Jira ticket
+        if: ${{ steps.check-jira-comments.outputs.comment-found != 'true' }}
+        uses: atlassian/gajira-comment@v3
+        with:
+          issue: ${{ needs.prepare.outputs.jiraTicketId }}
+          comment: "This ticket has been linked to an ephemeral deployment. The URL is: ${{ needs.deploy.outputs.hostname }}"
 
   destroy:
     name: Destroy Azure Container Instance


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-301" title="DEVOPS-301" target="_blank">DEVOPS-301</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Post ephemeral deployment link to Jira ticket when ephemeral deployment is ready</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://amuniversal.atlassian.net/images/icons/issuetypes/story.png" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- If deployment hasn't already been linked to the ticket, link the ephemeral deployment URL in Jira ticket after successful deployment.

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-301
- Ephemeral deployment link: 
![image](https://github.com/Andrews-McMeel-Universal/reusable_workflows/assets/111298136/04e0cbfa-681d-4051-9115-5e77018f6b7e)
- Testing environment: [![📦️ Deploy Ephemeral Environment](https://github.com/Andrews-McMeel-Universal/puzzle-society_ui/actions/workflows/ephemeral-deployments.yml/badge.svg?branch=story%2FDEVOPS-273%2Fupdate-dockerfile)](https://github.com/Andrews-McMeel-Universal/puzzle-society_ui/actions/workflows/ephemeral-deployments.yml) 
