### PR TITLE
[DEVOPS-XXX] Add option to set working-directory in Dotnet CI workflow

### DIFF
--- a/.github/workflows/dotnet-ci.yaml
+++ b/.github/workflows/dotnet-ci.yaml
@@ -6,6 +6,11 @@ on:
       environment:
         required: true
         type: string
+      projectName:
+        required: false
+        type: string
+        description: Project Directory Name
+        default: ""
       DOTNET_VERSION:
         required: true
         type: string
@@ -62,11 +67,14 @@ jobs:
 
       - name: Install dependencies
         if: steps.install-cache.outputs.cache-hit != 'true'
+        working-directory: ${{ inputs.projectName }}
         run: dotnet restore
 
       # Builds the app if the cache was broken
       - name: Build app
+        working-directory: ${{ inputs.projectName }}
         run: dotnet build -c Release --no-restore
 
       - name: Run tests
+        working-directory: ${{ inputs.projectName }}
         run: dotnet test --no-restore --verbosity normal


### PR DESCRIPTION
<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Added `projectName` input to Dotnet CI workflow that sets the `working-directory` for the `dotnet restore`, `dotnet build`, `dotnet test` commands if set.

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: N/A
