### PR TITLE
[DEVOPS-XXX] Add support multiple Nuget project libraries in Publish Nuget Package workflow

### DIFF
--- a/.github/workflows/bump-nuget-version.yaml
+++ b/.github/workflows/bump-nuget-version.yaml
@@ -7,6 +7,11 @@ on:
         required: false
         type: string
         description: Models Project Directory Name
+      libraryName:
+        required: false
+        type: string
+        description: Set to true if project has a separate library name
+        default: ""
     secrets:
       PAT_ACTION_CI:
         required: false
@@ -36,16 +41,22 @@ jobs:
         shell: pwsh
         run: |
           param (
-              [string]$ProjectName = ("${{ inputs.projectName }}" || (Split-Path -Path (Get-ChildItem ./ -Recurse | Where-Object { $_.PSIsContainer -and $_.Name.EndsWith(".Models")}) -Leaf))
+            [string]$ProjectName = ("${{ inputs.projectName }}" || (Split-Path -Path (Get-ChildItem ./ -Recurse | Where-Object { $_.PSIsContainer -and $_.Name.EndsWith(".Models")}) -Leaf)),
+              [string]$LibraryName = "${{ inputs.libraryName }}"
           )
 
           # Get project file contents
-          $ProjectFile = ($ProjectName + "/" + $ProjectName + ".csproj")
+          if ($LibraryName) {
+              $ProjectFile = ("$ProjectName/$LibraryName/$LibraryName.csproj")
+          }
+          else {
+              $ProjectFile = ("$ProjectName/$ProjectName.csproj")
+          }
           $ProjectFileContents = Get-Content $ProjectFile -Raw
 
           # Get version from project file
-          $VersionString = [RegEx]::Match($ProjectFileContents,"<Version>(.+?)</Version>")
-          $Version = [version]([RegEx]::Match($VersionString,"((?:\d+\.\d+\.\d+))")).Value
+          $VersionString = [RegEx]::Match($ProjectFileContents, "<Version>(.+?)</Version>")
+          $Version = [version]([RegEx]::Match($VersionString, "((?:\d+\.\d+\.\d+))")).Value
           Write-Host ("Current Version: " + $Version) -ForegroundColor DarkGray
 
           # Bump version number
@@ -63,8 +74,8 @@ jobs:
           Set-Content -Path $ProjectFile -Value $ProjectFileContents
 
           # Verify version number in project file
-          $UpdatedVersionString = [RegEx]::Match((Get-Content $ProjectFile -Raw),"<Version>(.+?)</Version>")
-          $UpdatedVersion = [version]([RegEx]::Match($UpdatedVersionString,"((?:\d+\.\d+\.\d+))")).Value
+          $UpdatedVersionString = [RegEx]::Match((Get-Content $ProjectFile -Raw), "<Version>(.+?)</Version>")
+          $UpdatedVersion = [version]([RegEx]::Match($UpdatedVersionString, "((?:\d+\.\d+\.\d+))")).Value
           if ($UpdatedVersion -eq $NewVersion) {
               Write-Host ('Version was updated correctly. Version string: "' + $UpdatedVersionString + '"') -ForegroundColor Green
           }

--- a/.github/workflows/bump-nuget-version.yaml
+++ b/.github/workflows/bump-nuget-version.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       projectName:
-        required: false
+        required: true
         type: string
         description: Models Project Directory Name
       libraryName:
@@ -30,8 +30,12 @@ jobs:
         id: files-changed
         run: |
           while IFS= read -r FILE; do
-            echo "${FILE}"
-            if [ "${FILE}" == "*.Models/*" ]; then
+            if [[ -n ${{ inputs.libraryName }} ]]; then
+              PROJECT_PATH="${{ inputs.projectName }}/${{ inputs.libraryName }}/*"
+            else
+              PROJECT_PATH="${{ inputs.projectName }}/*"
+            fi
+            if echo "${FILE}" | grep -Eq "${PROJECT_PATH}" ; then
               echo "models-changed=true" >> $GITHUB_OUTPUT
             fi
           done < <(git diff --name-only HEAD^ HEAD)
@@ -41,7 +45,7 @@ jobs:
         shell: pwsh
         run: |
           param (
-            [string]$ProjectName = ("${{ inputs.projectName }}" || (Split-Path -Path (Get-ChildItem ./ -Recurse | Where-Object { $_.PSIsContainer -and $_.Name.EndsWith(".Models")}) -Leaf)),
+              [string]$ProjectName = "${{ inputs.projectName }}",
               [string]$LibraryName = "${{ inputs.libraryName }}"
           )
 
@@ -85,8 +89,17 @@ jobs:
           }
 
       - name: Commit Changes
+        if: ${{ ! inputs.libraryName }}
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_user_name: amutechtest
           commit_user_email: amu_deploy@amuniversal.com
           commit_message: ⬆️ Bump Nuget version
+
+      - name: Commit Changes
+        if: ${{ inputs.libraryName }}
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_user_name: amutechtest
+          commit_user_email: amu_deploy@amuniversal.com
+          commit_message: ⬆️ Bump ${{ inputs.libraryName }} Nuget version

--- a/.github/workflows/publish-nuget-package.yaml
+++ b/.github/workflows/publish-nuget-package.yaml
@@ -11,6 +11,10 @@ on:
         required: true
         type: string
         description: ".NET SDK Version"
+      libraries:
+        required: false
+        type: string
+        description: Shared Library Name
     secrets:
       PAT_ACTION_CI:
         required: true
@@ -53,5 +57,14 @@ jobs:
         run: dotnet pack  --configuration Release
 
       - name: Push ${{ steps.project-name.outputs.projectName }} Package
+        if: ${{ ! inputs.libraries }}
         working-directory: "${{ steps.project-name.outputs.projectName }}/bin/Release/"
         run: dotnet nuget push "*.nupkg" --api-key "${{ secrets.GITHUB_TOKEN }}" --source "https://nuget.pkg.github.com/andrews-mcmeel-universal/index.json" --skip-duplicate
+
+      - name: Push ${{ steps.project-name.outputs.projectName }} Packages
+        if: ${{ inputs.libraries }}
+        run: |
+          for lib in ${{ inputs.libraries }}; do
+            cd "${{ steps.project-name.outputs.projectName }}/${lib}/bin/Release/"
+            dotnet nuget push "*.nupkg" --api-key "${{ secrets.GITHUB_TOKEN }}" --source "https://nuget.pkg.github.com/andrews-mcmeel-universal/index.json" --skip-duplicate
+          done

--- a/.github/workflows/publish-nuget-package.yaml
+++ b/.github/workflows/publish-nuget-package.yaml
@@ -65,6 +65,6 @@ jobs:
         if: ${{ inputs.libraries }}
         run: |
           for lib in ${{ inputs.libraries }}; do
-            cd "${{ steps.project-name.outputs.projectName }}/${lib}/bin/Release/"
+            cd "${{ github.workspace }}/${{ steps.project-name.outputs.projectName }}/${lib}/bin/Release/"
             dotnet nuget push "*.nupkg" --api-key "${{ secrets.GITHUB_TOKEN }}" --source "https://nuget.pkg.github.com/andrews-mcmeel-universal/index.json" --skip-duplicate
           done

--- a/.github/workflows/publish-nuget-package.yaml
+++ b/.github/workflows/publish-nuget-package.yaml
@@ -64,7 +64,8 @@ jobs:
       - name: Push ${{ steps.project-name.outputs.projectName }} Packages
         if: ${{ inputs.libraries }}
         run: |
-          for lib in ${{ inputs.libraries }}; do
-            cd "${{ github.workspace }}/${{ steps.project-name.outputs.projectName }}/${lib}/bin/Release/"
+          LIBRARIES="${{ inputs.libraries }}"
+          for LIBRARY in "${LIBRARIES[@]}"; do
+            cd "${{ github.workspace }}/${{ steps.project-name.outputs.projectName }}/${LIBRARY}/bin/Release/"
             dotnet nuget push "*.nupkg" --api-key "${{ secrets.GITHUB_TOKEN }}" --source "https://nuget.pkg.github.com/andrews-mcmeel-universal/index.json" --skip-duplicate
           done


### PR DESCRIPTION
<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

### Bump Nuget Package Version workflow changes

- Added `libraryName` input to Bump Nuget Package Version workflow to add support for multiple libraries contained within a single project.
- Applied prettier changes to Increment Version script
- Made `projectName` input mandatory since accounting for the exact library/project name does not scale well.
- Added a separate commit step if the `libraryName` input is passed into the workflow so that the commit messages have the `libraryName` included in them.

### Publish Nuget Package workflow changes

- Added `libraries` input to workflow to add support for multiple libraries contained within a single project.

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: N/A
