### PR TITLE
[DEVOPS-306] Use new `setBuildArguments` input in get-envs action

### DIFF
--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -207,47 +207,12 @@ jobs:
           environmentKeyVault: ${{ inputs.environmentKeyVault }}
 
       - name: Generate build args from Azure Key Vaults
-        shell: bash
-        run: |
-          ENVIRONMENT="${{ inputs.environment }}"
-          REPOSITORY_NAME="${{ inputs.repositoryName }}"
-          ENV_KEYVAULT_NAME="${{ inputs.environmentKeyVault }}"
-
-          # Check if searching for key vaults by repository name or otherwise, if key vault name argument is given
-          if [ -z "${ENV_KEYVAULT_NAME}" ]; then
-              # Search for key vault using tags
-              KEYVAULT_NAME=$(az keyvault list --query "[?tags.\"repository-name\" == '${REPOSITORY_NAME}' && tags.environment == '${ENVIRONMENT}'].name" --output tsv)
-          else
-              KEYVAULT_NAME="${ENV_KEYVAULT_NAME}"
-          fi
-
-          # Get key vault object
-          KEYVAULT=$(az keyvault list --query "[?name == '${KEYVAULT_NAME}']" )
-
-          # Check if key vault exists
-          if ! echo "${KEYVAULT}" | grep -Eq "\w"; then
-              echo -e "${RED}Invalid value provided for 'KeyVaultName'. Please confirm a Key Vault exists under the name specified. Value provided: ${KEYVAULT_NAME}"
-              exit 1
-          fi
-          KEYVAULT_NAME="${KEYVAULT_NAME// /}"
-
-          # Set secrets list
-          SECRETS=$(az keyvault secret list --vault-name "${KEYVAULT_NAME}" --query "[?contentType == 'BuildArg Env' || contentType == 'BuildArg'].name" --output tsv)
-
-          # Loop through secrets and add them to .env
-          if echo "${SECRETS}" | grep -Eq "\w"; then
-              while IFS= read -r SECRET; do
-                  # Convert to upper case snake case and remove quotes
-                  SECRET_NAME=$(echo "${SECRET}" | tr '[:upper:][:lower:]' '[:lower:][:upper:]' | tr "-" "_" | tr -d '"')
-
-                  # Get secret value and set it to the secret name
-                  SECRET_VALUE=$(az keyvault secret show --vault-name "${KEYVAULT_NAME}" -n "${SECRET}" --query "value" --output tsv)
-
-                  # Add secret to file
-                  BUILDARGS="${BUILDARGS} --build-arg ${SECRET_NAME}=${SECRET_VALUE}"
-              done < <(echo "${SECRETS[*]}")
-          fi
-          echo "buildArguments=${BUILDARGS}" >> $GITHUB_ENV
+        uses: Andrews-McMeel-Universal/get-envs@v1
+        with:
+          azurecredentials: ${{ secrets.azureCredentials }}
+          environment: ${{ inputs.environment }}
+          environmentKeyVault: ${{ inputs.environmentKeyVault }}
+          setBuildArguments: true
 
       - name: Login to Azure Container Registry
         uses: Azure/docker-login@v1

--- a/.github/workflows/ephemeral-deploy.yaml
+++ b/.github/workflows/ephemeral-deploy.yaml
@@ -135,47 +135,12 @@ jobs:
           echo "environmentVariables=${ENVIRONMENT_VARIABLES}" >> $GITHUB_OUTPUT
 
       - name: Generate build args from Azure Key Vaults
-        id: build-args
-        run: |
-          ENVIRONMENT="${{ needs.prepare.outputs.environment }}"
-          REPOSITORY_NAME="${{ inputs.repositoryName }}"
-          ENV_KEYVAULT_NAME="${{ inputs.environmentKeyVaultPrefix }}-${{ needs.prepare.outputs.environment }}"
-
-          # Check if searching for key vaults by repository name or otherwise, if key vault name argument is given
-          if [ -z "${ENV_KEYVAULT_NAME}" ]; then
-              # Search for key vault using tags
-              KEYVAULT_NAME=$(az keyvault list --query "[?tags.\"repository-name\" == '${REPOSITORY_NAME}' && tags.environment == '${ENVIRONMENT}'].name" --output tsv)
-          else
-              KEYVAULT_NAME="${ENV_KEYVAULT_NAME}"
-          fi
-
-          # Get key vault object
-          KEYVAULT=$(az keyvault list --query "[?name == '${KEYVAULT_NAME}']" )
-
-          # Check if key vault exists
-          if ! echo "${KEYVAULT}" | grep -Eq "\w"; then
-              echo -e "${RED}Invalid value provided for 'KeyVaultName'. Please confirm a Key Vault exists under the name specified. Value provided: ${KEYVAULT_NAME}"
-              exit 1
-          fi
-          KEYVAULT_NAME="${KEYVAULT_NAME// /}"
-
-          # Set secrets list
-          SECRETS=$(az keyvault secret list --vault-name "${KEYVAULT_NAME}" --query "[?contentType == 'BuildArg Env' || contentType == 'BuildArg'].name" --output tsv)
-
-          # Loop through secrets and add them to .env
-          if echo "${SECRETS}" | grep -Eq "\w"; then
-              while IFS= read -r SECRET; do
-                  # Convert to upper case snake case and remove quotes
-                  SECRET_NAME=$(echo "${SECRET}" | tr '[:upper:][:lower:]' '[:lower:][:upper:]' | tr "-" "_" | tr -d '"')
-
-                  # Get secret value and set it to the secret name
-                  SECRET_VALUE=$(az keyvault secret show --vault-name "${KEYVAULT_NAME}" -n "${SECRET}" --query "value" --output tsv)
-
-                  # Add secret to file
-                  BUILDARGS="${BUILDARGS} --build-arg ${SECRET_NAME}=${SECRET_VALUE}"
-              done < <(echo "${SECRETS[*]}")
-          fi
-          echo "buildArguments=${BUILDARGS}" >> $GITHUB_OUTPUT
+        uses: Andrews-McMeel-Universal/get-envs@v1
+        with:
+          azurecredentials: ${{ secrets.azureCredentials }}
+          environment: ${{ needs.prepare.outputs.environment }}
+          environmentKeyVault: ${{ inputs.environmentKeyVaultPrefix }}-${{ needs.prepare.outputs.environment }}
+          setBuildArguments: true
 
       - name: Login to Azure Container Registry
         uses: Azure/docker-login@v1
@@ -186,7 +151,7 @@ jobs:
 
       - name: Build & Push Docker Image
         run: |
-          docker build ${{ inputs.dockerFilePath }} ${{ steps.build-args.outputs.buildArguments }} -t "${{ secrets.registryHostName }}/${{ inputs.dockerImageName }}:${{ needs.prepare.outputs.jiraTicketId }}"
+          docker build ${{ inputs.dockerFilePath }} ${{ env.buildArguments }} -t "${{ secrets.registryHostName }}/${{ inputs.dockerImageName }}:${{ needs.prepare.outputs.jiraTicketId }}"
           docker push -a "${{ secrets.registryHostName }}/${{ inputs.dockerImageName }}"
 
       - name: Deploy Azure Container App


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-306" title="DEVOPS-306" target="_blank">DEVOPS-306</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Add build arg compatibility to get-envs custom GitHub action</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://amuniversal.atlassian.net/images/icons/issuetypes/story.png" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Development Env</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Switched to using `setBuildArguments` input with the get-envs action in the "Generate build args from Azure Key Vaults" step in the AKS deploy workflow
- Switched to using `setBuildArguments` input with the get-envs action in the "Generate build args from Azure Key Vaults" step in the Ephemeral Deployments workflow

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-306
