### PR TITLE
[DEVOPS-309] Switch to Docker buildx commands to fix failing builds

### DIFF
--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -258,7 +258,7 @@ jobs:
 
       - name: Build & Push Docker Image
         run: |
-          docker build ${{ inputs.dockerFilePath }} ${{ env.buildArguments }} -t "${{ secrets.registryHostName }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
+          docker buildx build ${{ inputs.dockerFilePath }} ${{ env.buildArguments }} -t "${{ secrets.registryHostName }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}"
           if [[ "${{ inputs.environment }}" == "production" ]] ; then
             docker tag "${{ secrets.registryHostName }}/${{ inputs.dockerImageName }}:${{ inputs.dockerImageTag }}" "${{ secrets.registryHostName }}/${{ inputs.dockerImageName }}:latest"
           fi

--- a/.github/workflows/ephemeral-deploy.yaml
+++ b/.github/workflows/ephemeral-deploy.yaml
@@ -186,7 +186,7 @@ jobs:
 
       - name: Build & Push Docker Image
         run: |
-          docker build ${{ inputs.dockerFilePath }} ${{ steps.build-args.outputs.buildArguments }} -t "${{ secrets.registryHostName }}/${{ inputs.dockerImageName }}:${{ needs.prepare.outputs.jiraTicketId }}"
+          docker buildx build ${{ inputs.dockerFilePath }} ${{ steps.build-args.outputs.buildArguments }} -t "${{ secrets.registryHostName }}/${{ inputs.dockerImageName }}:${{ needs.prepare.outputs.jiraTicketId }}"
           docker push -a "${{ secrets.registryHostName }}/${{ inputs.dockerImageName }}"
 
       - name: Deploy Azure Container App
@@ -277,7 +277,7 @@ jobs:
 
       - name: Build & Push Docker Image with updated Next.js variables
         run: |
-          docker build --no-cache ${{ inputs.dockerFilePath }} ${{ steps.next-vars.outputs.buildArguments }} -t "${{ secrets.registryHostName }}/${{ inputs.dockerImageName }}:${{ needs.prepare.outputs.jiraTicketId }}"
+          docker buildx build --no-cache ${{ inputs.dockerFilePath }} ${{ steps.next-vars.outputs.buildArguments }} -t "${{ secrets.registryHostName }}/${{ inputs.dockerImageName }}:${{ needs.prepare.outputs.jiraTicketId }}"
           docker push -a "${{ secrets.registryHostName }}/${{ inputs.dockerImageName }}"
 
       - name: Login via Az module


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-309" title="DEVOPS-309" target="_blank">DEVOPS-309</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Switch to docker buildx commands in reusable workflows</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://amuniversal.atlassian.net/images/icons/issuetypes/story.png" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Update `docker build` commands to `docker buildx build` to account for the new `buildx` command being the default in the latest Ubuntu images.

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-309
- Example failed build: https://github.com/Andrews-McMeel-Universal/puzzle-society_ui/actions/runs/6866150321/job/18671869277
