### PR TITLE
[DEVOPS-313] Fix problem with broken dependencies when running prettier

### DIFF
--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -25,9 +25,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.PAT_ACTION_CI }}
+          ref: ${{ github.head_ref }}
 
-      - name: Run yarn install
-        if: ${{ inputs.prettierPlugins }}
+      - if: ${{ inputs.prettierPlugins }}
         run: yarn install
 
       - uses: creyD/prettier_action@v4.3

--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -28,7 +28,9 @@ jobs:
 
       - name: Use cache-next-install action
         if: ${{ inputs.runYarnInstall }}
-        uses: Andrews-McMeel-Universal/cache-next-install@v1
+        uses: Andrews-McMeel-Universal/cache-next-install@story/DEVOPS-313/fix-prettier-yarn-install
+        with:
+          install-dev-dependencies: "true"
 
       - uses: actionsx/prettier@v3
         with:

--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -26,16 +26,16 @@ jobs:
         with:
           token: ${{ secrets.PAT_ACTION_CI }}
 
+      - name: Run yarn install
+        if: ${{ inputs.prettierPlugins }}
+        run: yarn install
+
       - uses: creyD/prettier_action@v4.3
         with:
           prettier_options: --write .
           prettier_plugins: ${{ inputs.prettierPlugins }}
-
-      - uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_user_name: amutechtest
-          commit_user_email: amu_deploy@amuniversal.com
           commit_message: Apply prettier changes
+          github_token: ${{ secrets.PAT_ACTION_CI }}
 
   lint-workflows:
     name: Workflow linter

--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -28,7 +28,9 @@ jobs:
 
       - name: Use cache-next-install action
         if: ${{ inputs.runYarnInstall }}
-        uses: Andrews-McMeel-Universal/cache-yarn-install@v1
+        uses: Andrews-McMeel-Universal/cache-next-install@story/DEVOPS-313/fix-prettier-yarn-install
+        with:
+          install-dev-dependencies: "true"
 
       - uses: actionsx/prettier@v3
         with:

--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -26,12 +26,6 @@ jobs:
         with:
           token: ${{ secrets.PAT_ACTION_CI }}
 
-      - name: Use cache-next-install action
-        if: ${{ inputs.runYarnInstall }}
-        uses: Andrews-McMeel-Universal/cache-next-install@story/DEVOPS-313/fix-prettier-yarn-install
-        with:
-          install-dev-dependencies: "true"
-
       - uses: creyD/prettier_action@v4.3
         with:
           prettier_options: --write .

--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -8,9 +8,9 @@ on:
       runPrettier:
         default: true
         type: boolean
-      runYarnInstall:
-        default: false
-        type: boolean
+      prettierPlugins:
+        description: Install Prettier plugins, i.e. '@prettier/plugin-php @prettier/plugin-other'
+        type: string
     secrets:
       PAT_ACTION_CI:
         required: true
@@ -32,9 +32,10 @@ jobs:
         with:
           install-dev-dependencies: "true"
 
-      - uses: actionsx/prettier@v3
+      - uses: creyD/prettier_action@v4.3
         with:
-          args: --write .
+          prettier_options: --write .
+          prettier_plugins: ${{ inputs.prettierPlugins }}
 
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -28,9 +28,7 @@ jobs:
 
       - name: Use cache-next-install action
         if: ${{ inputs.runYarnInstall }}
-        uses: Andrews-McMeel-Universal/cache-next-install@story/DEVOPS-313/fix-prettier-yarn-install
-        with:
-          install-dev-dependencies: "true"
+        uses: Andrews-McMeel-Universal/cache-yarn-install@v1
 
       - uses: actionsx/prettier@v3
         with:


### PR DESCRIPTION
<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Replaced `runYarnInstall` input in favor of `prettierPlugins` so that the new prettier action can install any plugins that are skipped when running `yarn install`.

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-313
- Working test: https://github.com/Andrews-McMeel-Universal/gocomics_ui/actions/runs/6882794807/job/18722467513
