### PR TITLE
[DEVOPS-324] Use repository config files when running prettier

### DIFF
--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: creyD/prettier_action@v4.3
         with:
-          prettier_options: --write . --config ./.prettierrc --config ./.prettierrc.json
+          prettier_options: --write . --config ./.prettierrc.js --config ./.prettierrc.json
           prettier_plugins: ${{ inputs.prettierPlugins }}
           commit_message: Apply prettier changes
           github_token: ${{ secrets.PAT_ACTION_CI }}

--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: creyD/prettier_action@v4.3
         with:
-          prettier_options: --write .
+          prettier_options: --write . --config ./.prettierrc --config ./.prettierrc.json
           prettier_plugins: ${{ inputs.prettierPlugins }}
           commit_message: Apply prettier changes
           github_token: ${{ secrets.PAT_ACTION_CI }}


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-324" title="DEVOPS-324" target="_blank">DEVOPS-324</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Prettier in simple lint workflow not respecting prettier config files</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://amuniversal.atlassian.net/images/icons/issuetypes/story.png" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Use repository config files when running prettier

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-324
