### PR TITLE
[DEVOPS-339] Fix if conditions in ephemeral deployment workflow

### DIFF
--- a/.github/workflows/ephemeral-deploy.yaml
+++ b/.github/workflows/ephemeral-deploy.yaml
@@ -118,7 +118,7 @@ jobs:
 
   deploy:
     name: Deploy Azure Container Instance
-    if: github.event_name == 'pull_request' && ((github.event.action == 'labeled' && startsWith(github.event.label.name, 'preview:')) || contains(github.event.pull_request.labels.*.name, 'preview:development'))
+    if: github.event_name == 'pull_request' && ((github.event.action == 'labeled' && startsWith(github.event.label.name, 'preview:')) || (contains(github.event.pull_request.labels.*.name, 'preview:development') || contains(github.event.pull_request.labels.*.name, 'preview:staging') || contains(github.event.pull_request.labels.*.name, 'preview:production')))
     needs: [prepare]
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/ephemeral-deploy.yaml
+++ b/.github/workflows/ephemeral-deploy.yaml
@@ -118,7 +118,7 @@ jobs:
 
   deploy:
     name: Deploy Azure Container Instance
-    if: ${{ github.event_name == 'pull_request' && ((github.event.action == 'labeled' && startsWith(github.event.label.name, 'preview:')) || contains(github.event.pull_request.labels.*.name, 'preview:')) }}
+    if: startsWith(github.event.label.name, 'preview:') || contains(github.event.pull_request.labels.*.name, 'preview:')
     needs: [prepare]
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/ephemeral-deploy.yaml
+++ b/.github/workflows/ephemeral-deploy.yaml
@@ -60,7 +60,7 @@ env:
 jobs:
   prepare:
     name: Preparation Step
-    if: ${{ github.event.action == 'labeled' && startsWith(github.event.label.name, 'preview:') || github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'preview:') }}
+    if: ${{ github.event.action == 'labeled' && startsWith(github.event.label.name, 'preview:') || github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'preview:') || github.event_name == 'pull_request' && github.event.action == 'closed' }}
     runs-on: ubuntu-latest
     steps:
       - name: Get Jira ticket ID
@@ -119,6 +119,7 @@ jobs:
 
   deploy:
     name: Deploy Azure Container Instance
+    if: ${{ github.event.action == 'labeled' && startsWith(github.event.label.name, 'preview:') || github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'preview:') }}
     needs: [prepare]
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/ephemeral-deploy.yaml
+++ b/.github/workflows/ephemeral-deploy.yaml
@@ -118,7 +118,7 @@ jobs:
 
   deploy:
     name: Deploy Azure Container Instance
-    if: startsWith(github.event.label.name, 'preview:') || contains(github.event.pull_request.labels.*.name, 'preview:')
+    if: github.event_name == 'pull_request' && ((github.event.action == 'labeled' && startsWith(github.event.label.name, 'preview:')) || contains(github.event.pull_request.labels.*.name, 'preview:'))
     needs: [prepare]
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/ephemeral-deploy.yaml
+++ b/.github/workflows/ephemeral-deploy.yaml
@@ -118,7 +118,7 @@ jobs:
 
   deploy:
     name: Deploy Azure Container Instance
-    if: github.event_name == 'pull_request' && ((github.event.action == 'labeled' && startsWith(github.event.label.name, 'preview:')) || contains(github.event.pull_request.labels.*.name, 'preview:'))
+    if: github.event_name == 'pull_request' && ((github.event.action == 'labeled' && startsWith(github.event.label.name, 'preview:')) || contains(github.event.pull_request.labels.*.name, 'preview:development'))
     needs: [prepare]
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/ephemeral-deploy.yaml
+++ b/.github/workflows/ephemeral-deploy.yaml
@@ -60,7 +60,7 @@ env:
 jobs:
   prepare:
     name: Preparation Step
-    if: ${{ github.event.action == 'labeled' && startsWith(github.event.label.name, 'preview:') || github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'preview:') || github.event_name == 'pull_request' && github.event.action == 'closed' }}
+    if: ${{ (github.event.action == 'labeled' && startsWith(github.event.label.name, 'preview:')) || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'preview:')) || (github.event_name == 'pull_request' && github.event.action == 'closed') }}
     runs-on: ubuntu-latest
     steps:
       - name: Get Jira ticket ID
@@ -119,7 +119,7 @@ jobs:
 
   deploy:
     name: Deploy Azure Container Instance
-    if: ${{ github.event.action == 'labeled' && startsWith(github.event.label.name, 'preview:') || github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'preview:') }}
+    if: ${{ (github.event.action == 'labeled' && startsWith(github.event.label.name, 'preview:')) || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'preview:')) }}
     needs: [prepare]
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/ephemeral-deploy.yaml
+++ b/.github/workflows/ephemeral-deploy.yaml
@@ -118,7 +118,7 @@ jobs:
 
   deploy:
     name: Deploy Azure Container Instance
-    if: ${{ (github.event.action == 'labeled' && startsWith(github.event.label.name, 'preview:')) || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'preview:')) }}
+    if: ${{ github.event_name == 'pull_request' && ((github.event.action == 'labeled' && startsWith(github.event.label.name, 'preview:')) || contains(github.event.pull_request.labels.*.name, 'preview:')) }}
     needs: [prepare]
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/ephemeral-deploy.yaml
+++ b/.github/workflows/ephemeral-deploy.yaml
@@ -60,7 +60,6 @@ env:
 jobs:
   prepare:
     name: Preparation Step
-    if: ${{ (github.event.action == 'labeled' && startsWith(github.event.label.name, 'preview:')) || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'preview:')) || (github.event_name == 'pull_request' && github.event.action == 'closed') }}
     runs-on: ubuntu-latest
     steps:
       - name: Get Jira ticket ID


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-339" title="DEVOPS-339" target="_blank">DEVOPS-339</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Ephemeral deployment workflow not deleting deployment or B2C redirect URIs after PR closes</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://amuniversal.atlassian.net/images/icons/issuetypes/story.png" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>To Do</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Fix if conditions in ephemeral deployment workflow
  - Moved if condition from the `prepare` job to the `deploy` job.
  - Fixed workflow triggers on a PR's 'synchronize', 'reopened', and 'opened' events by checking for all iterations of the `preview:` label.

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-339
- Testing environment: [![📦️ Deploy Ephemeral Environment](https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/actions/workflows/ephemeral-deployments.yml/badge.svg?branch=story%2FDEVOPS-XXX%2Ftest-ephemeral-deployments)](https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/actions/workflows/ephemeral-deployments.yml)
