### PR TITLE
[DEVOPS-343] Extend container app name to 32 characters

### DIFF
--- a/.github/workflows/ephemeral-deploy.yaml
+++ b/.github/workflows/ephemeral-deploy.yaml
@@ -103,18 +103,19 @@ jobs:
             exit 1
           fi
 
-      - name: Generate checksum for URL
+      - name: Generate container app name
         id: checksum
         run: |
-          FULL_CHECKSUM=$(echo -n '${{ steps.repository-name.outputs.repositoryName }}-${{ steps.jira-ticket.outputs.jiraTicketIdLc }}' | sha256sum | awk '{print $1}')
-          SHORT_CHECKSUM=${FULL_CHECKSUM:0:4}
-          echo "urlChecksum=${SHORT_CHECKSUM}" >> $GITHUB_OUTPUT
+          CHECKSUM=$(echo -n '${{ steps.repository-name.outputs.repositoryName }}-${{ steps.jira-ticket.outputs.jiraTicketIdLc }}' | sha256sum | awk '{print $1}')
+          URL="${{ steps.jira-ticket.outputs.jiraTicketIdLc }}-${CHECKSUM}"
+          SHORT_URL=${URL:0:32}
+          echo "containerAppName=${SHORT_URL}" >> $GITHUB_OUTPUT
     outputs:
       environment: ${{ steps.environment.outputs.environment }}
       jiraTicketId: ${{ steps.jira-ticket.outputs.jiraTicketId }}
       jiraTicketIdLc: ${{ steps.jira-ticket.outputs.jiraTicketIdLc }}
       repositoryName: ${{ steps.repository-name.outputs.repositoryName }}
-      urlChecksum: ${{ steps.checksum.outputs.urlChecksum }}
+      containerAppName: ${{ steps.checksum.outputs.containerAppName }}
 
   deploy:
     name: Deploy Azure Container Instance
@@ -176,7 +177,7 @@ jobs:
           registryUsername: ${{ secrets.registryUserName }}
           registryPassword: ${{ secrets.registryPassword }}
           imageToDeploy: ${{ secrets.registryHostName }}/${{ inputs.dockerImageName }}:${{ needs.prepare.outputs.jiraTicketId }}
-          containerAppName: ${{ needs.prepare.outputs.jiraTicketIdLc }}-${{ needs.prepare.outputs.urlChecksum }}
+          containerAppName: ${{ needs.prepare.outputs.containerAppName }}
           resourceGroup: ${{ inputs.clusterResourceGroup }}
           targetPort: ${{ steps.target-port.outputs.targetPort }}
           location: ${{ inputs.azureResourceLocation }}
@@ -186,12 +187,12 @@ jobs:
 
       - name: Add access restrictions to Container App ingress
         run: |
-          az containerapp ingress access-restriction set --action Allow --ip-address "${{ inputs.ingressWhitelist }}" --rule-name allow-range --name "${{ needs.prepare.outputs.jiraTicketIdLc }}-${{ needs.prepare.outputs.urlChecksum }}" --resource-group "${{ inputs.clusterResourceGroup }}"
+          az containerapp ingress access-restriction set --action Allow --ip-address "${{ inputs.ingressWhitelist }}" --rule-name allow-range --name "${{ needs.prepare.outputs.containerAppName }}" --resource-group "${{ inputs.clusterResourceGroup }}"
 
       - name: Get Container App Hostname
         id: hostname
         run: |
-          HOSTNAME=$(az containerapp list --query "[?name == '${{ needs.prepare.outputs.jiraTicketIdLc }}-${{ needs.prepare.outputs.urlChecksum }}'].properties.configuration.ingress.fqdn" -o tsv)
+          HOSTNAME=$(az containerapp list --query "[?name == '${{ needs.prepare.outputs.containerAppName }}'].properties.configuration.ingress.fqdn" -o tsv)
           echo "hostname=https://${HOSTNAME}" >> $GITHUB_OUTPUT
 
       - name: Check if app is a Next.js application
@@ -290,7 +291,7 @@ jobs:
           registryUsername: ${{ secrets.registryUserName }}
           registryPassword: ${{ secrets.registryPassword }}
           imageToDeploy: ${{ secrets.registryHostName }}/${{ inputs.dockerImageName }}:${{ needs.prepare.outputs.jiraTicketId }}
-          containerAppName: ${{ needs.prepare.outputs.jiraTicketIdLc }}-${{ needs.prepare.outputs.urlChecksum }}
+          containerAppName: ${{ needs.prepare.outputs.containerAppName }}
           resourceGroup: ${{ inputs.clusterResourceGroup }}
           targetPort: ${{ needs.deploy.outputs.targetPort }}
           location: ${{ inputs.azureResourceLocation }}
@@ -360,7 +361,7 @@ jobs:
 
       - name: Delete Azure Resources
         run: |
-          az containerapp delete --resource-group ${{ inputs.clusterResourceGroup }} --name ${{ needs.prepare.outputs.jiraTicketIdLc }}-${{ needs.prepare.outputs.urlChecksum }} --yes
+          az containerapp delete --resource-group ${{ inputs.clusterResourceGroup }} --name ${{ needs.prepare.outputs.containerAppName }} --yes
           az acr repository delete -n ${{ secrets.registryHostName }} --image ${{ inputs.dockerImageName }}:${{ needs.prepare.outputs.jiraTicketId }} --yes
 
       - name: Remove Azure B2C Redirect URI


### PR DESCRIPTION
<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-343" title="DEVOPS-343" target="_blank">DEVOPS-343</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Extend URL checksum to max character limit in ephemeral deploy workflow</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://amuniversal.atlassian.net/images/icons/issuetypes/story.png" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Extend container app name to 32 characters to make the B2C redirect URIs more unique for Next.js ephemeral deployments.

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-343
- Testing environment: [![📦️ Deploy Ephemeral Environment](https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/actions/workflows/ephemeral-deployments.yml/badge.svg?branch=story%2FDEVOPS-343%2Fextend-url-checksum-in-eph-deploy-url)](https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/actions/workflows/ephemeral-deployments.yml)
- End result: https://devops-343-70ffb24a9750c5755af0c.jollysea-24bf33a3.centralus.azurecontainerapps.io/
