### PR TITLE
[DEVOPS-349] Move Jira ticket ID to the end of app name in ephemeral deployments workflow

### DIFF
--- a/.github/workflows/ephemeral-deploy.yaml
+++ b/.github/workflows/ephemeral-deploy.yaml
@@ -99,8 +99,7 @@ jobs:
       - name: Generate container app name
         id: checksum
         run: |
-          REPOSITORY_NAME="${{ inputs.repositoryName }}"
-          CHECKSUM=$(echo -n '${REPOSITORY_NAME}-${{ steps.jira-ticket.outputs.jiraTicketIdLc }}' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]//g' | sed 's/--/-/g' | sed 's/^-//;s/-$//' | cut -c1-31 | md5sum | cut -d' ' -f1 | sed 's/^\([0-9]\)/a\1/')
+          CHECKSUM=$(echo -n '${{ inputs.repositoryName }}-${{ steps.jira-ticket.outputs.jiraTicketIdLc }}' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]//g' | sed 's/--/-/g' | sed 's/^-//;s/-$//' | cut -c1-31 | md5sum | cut -d' ' -f1 | sed 's/^\([0-9]\)/a\1/')
           SHORT_CHECKSUM=${CHECKSUM:0:20}
           CONTAINER_APP_NAME="${SHORT_CHECKSUM}-${{ steps.jira-ticket.outputs.jiraTicketIdLc }}"
           echo "containerAppName=${CONTAINER_APP_NAME}" >> $GITHUB_OUTPUT

--- a/.github/workflows/ephemeral-deploy.yaml
+++ b/.github/workflows/ephemeral-deploy.yaml
@@ -107,9 +107,9 @@ jobs:
         id: checksum
         run: |
           CHECKSUM=$(echo -n '${{ steps.repository-name.outputs.repositoryName }}-${{ steps.jira-ticket.outputs.jiraTicketIdLc }}' | sha256sum | awk '{print $1}')
-          URL="${{ steps.jira-ticket.outputs.jiraTicketIdLc }}-${CHECKSUM}"
-          SHORT_URL=${URL:0:32}
-          echo "containerAppName=${SHORT_URL}" >> $GITHUB_OUTPUT
+          SHORT_CHECKSUM=${CHECKSUM:0:16}
+          CONTAINER_APP_NAME="${SHORT_CHECKSUM}-${{ steps.jira-ticket.outputs.jiraTicketIdLc }}"
+          echo "containerAppName=${CONTAINER_APP_NAME}" >> $GITHUB_OUTPUT
     outputs:
       environment: ${{ steps.environment.outputs.environment }}
       jiraTicketId: ${{ steps.jira-ticket.outputs.jiraTicketId }}

--- a/.github/workflows/ephemeral-deploy.yaml
+++ b/.github/workflows/ephemeral-deploy.yaml
@@ -82,13 +82,6 @@ jobs:
           echo "jiraTicketIdLc=${JIRA_TICKET_ID_LC}" >> $GITHUB_OUTPUT
           echo "jiraTicketId=${JIRA_TICKET_ID}" >> $GITHUB_OUTPUT
 
-      - name: Fix repository name
-        id: repository-name
-        run: |
-          REPOSITORY_NAME="${{ inputs.repositoryName }}"
-          REPO_NAME_SHORT=$(echo "${REPOSITORY_NAME:0:21}" | tr '[:upper:]' '[:lower:]' | tr "_" "-")
-          echo "repositoryName=${REPO_NAME_SHORT}" >> $GITHUB_OUTPUT
-
       - name: Get Environment
         id: environment
         shell: bash
@@ -106,15 +99,15 @@ jobs:
       - name: Generate container app name
         id: checksum
         run: |
-          CHECKSUM=$(echo -n '${{ steps.repository-name.outputs.repositoryName }}-${{ steps.jira-ticket.outputs.jiraTicketIdLc }}' | sha256sum | awk '{print $1}')
-          SHORT_CHECKSUM=${CHECKSUM:0:16}
+          REPOSITORY_NAME="${{ inputs.repositoryName }}"
+          CHECKSUM=$(echo -n '${REPOSITORY_NAME}-${{ steps.jira-ticket.outputs.jiraTicketIdLc }}' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]//g' | sed 's/--/-/g' | sed 's/^-//;s/-$//' | cut -c1-31 | md5sum | cut -d' ' -f1 | sed 's/^\([0-9]\)/a\1/')
+          SHORT_CHECKSUM=${CHECKSUM:0:20}
           CONTAINER_APP_NAME="${SHORT_CHECKSUM}-${{ steps.jira-ticket.outputs.jiraTicketIdLc }}"
           echo "containerAppName=${CONTAINER_APP_NAME}" >> $GITHUB_OUTPUT
     outputs:
       environment: ${{ steps.environment.outputs.environment }}
       jiraTicketId: ${{ steps.jira-ticket.outputs.jiraTicketId }}
       jiraTicketIdLc: ${{ steps.jira-ticket.outputs.jiraTicketIdLc }}
-      repositoryName: ${{ steps.repository-name.outputs.repositoryName }}
       containerAppName: ${{ steps.checksum.outputs.containerAppName }}
 
   deploy:


### PR DESCRIPTION
<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-349" title="DEVOPS-349" target="_blank">DEVOPS-349</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Remove Jira ticket ID from ephemeral deployment app names</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://amuniversal.atlassian.net/images/icons/issuetypes/story.png" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>To Do</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Move Jira ticket ID to the end of app name in ephemeral deployments workflow

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-349
- Testing environment: [![📦️ Deploy Ephemeral Environment](https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/actions/workflows/ephemeral-deployments.yml/badge.svg?branch=story%2FDEVOPS-349%2Fremove-jira-ticket-id-from-eph-deploy-names)](https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/actions/workflows/ephemeral-deployments.yml)
- Generated URL: https://a83191e8507fa958a2fa-devops-349.jollysea-24bf33a3.centralus.azurecontainerapps.io/
