### PR TITLE
[DEVOPS-376] Fix prettier not respecting configuration files

### DIFF
--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -27,19 +27,6 @@ jobs:
           token: ${{ secrets.PAT_ACTION_CI }}
           ref: ${{ github.head_ref }}
 
-      - name: Run yarn install
-        if: ${{ inputs.prettierPlugins }}
-        uses: Andrews-McMeel-Universal/cache-yarn-install@v1
-
-      - name: Set prettier plugin arguments
-        id: prettier-plugins
-        if: ${{ inputs.prettierPlugins }}
-        run: |
-          for PLUGIN in ${{ inputs.prettierPlugins }}; do
-            PRETTIER_PLUGINS="$PRETTIER_PLUGINS --plugin $PLUGIN"
-          done
-          echo "prettierPlugins=$PRETTIER_PLUGINS" >> $GITHUB_OUTPUT
-
       - name: Check if .prettierrc.js file exists
         id: prettier-config-js
         uses: andstor/file-existence-action@v2
@@ -56,7 +43,7 @@ jobs:
         if: ${{ steps.prettier-config-js.outputs.files_exists == 'true' }}
         uses: creyD/prettier_action@v4.3
         with:
-          prettier_options: --write . --ignore-path ./.prettierignore --config ./.prettierrc.js ${{ steps.prettier-plugins.outputs.prettierPlugins }}
+          prettier_options: --write . --ignore-path ./.prettierignore --config ./.prettierrc.js
           prettier_plugins: ${{ inputs.prettierPlugins }}
           commit_message: "[Simple Linter] Apply prettier changes"
           only_changed: true
@@ -65,7 +52,7 @@ jobs:
         if: ${{ steps.prettier-config-json.outputs.files_exists == 'true' }}
         uses: creyD/prettier_action@v4.3
         with:
-          prettier_options: --write . --ignore-path ./.prettierignore --config ./.prettierrc.json ${{ steps.prettier-plugins.outputs.prettierPlugins }}
+          prettier_options: --write . --ignore-path ./.prettierignore --config ./.prettierrc.json
           prettier_plugins: ${{ inputs.prettierPlugins }}
           commit_message: "[Simple Linter] Apply prettier changes"
           only_changed: true

--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -27,6 +27,15 @@ jobs:
           token: ${{ secrets.PAT_ACTION_CI }}
           ref: ${{ github.head_ref }}
 
+      - name: Set prettier plugin arguments
+        id: prettier-plugins
+        if: ${{ inputs.prettierPlugins }}
+        run: |
+          for PLUGIN in ${{ inputs.prettierPlugins }}; do
+            PRETTIER_PLUGINS="$PRETTIER_PLUGINS --plugin $PLUGIN"
+          done
+          echo "prettierPlugins=$PRETTIER_PLUGINS" >> $GITHUB_OUTPUT
+
       - name: Check if .prettierrc.js file exists
         id: prettier-config-js
         uses: andstor/file-existence-action@v2
@@ -43,7 +52,7 @@ jobs:
         if: ${{ steps.prettier-config-js.outputs.files_exists == 'true' }}
         uses: creyD/prettier_action@v4.3
         with:
-          prettier_options: --write . --ignore-path ./.prettierignore --config ./.prettierrc.js
+          prettier_options: --write . --ignore-path ./.prettierignore --config ./.prettierrc.js ${{ steps.prettier-plugins.outputs.prettierPlugins }}
           prettier_plugins: ${{ inputs.prettierPlugins }}
           commit_message: "[Simple Linter] Apply prettier changes"
           only_changed: true
@@ -52,7 +61,7 @@ jobs:
         if: ${{ steps.prettier-config-json.outputs.files_exists == 'true' }}
         uses: creyD/prettier_action@v4.3
         with:
-          prettier_options: --write . --ignore-path ./.prettierignore --config ./.prettierrc.json
+          prettier_options: --write . --ignore-path ./.prettierignore --config ./.prettierrc.json ${{ steps.prettier-plugins.outputs.prettierPlugins }}
           prettier_plugins: ${{ inputs.prettierPlugins }}
           commit_message: "[Simple Linter] Apply prettier changes"
           only_changed: true

--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -29,9 +29,7 @@ jobs:
 
       - name: Install prettier modules
         if: ${{ inputs.prettierPlugins }}
-        env:
-          NODE_ENV: development
-        run: yarn install
+        run: NODE_ENV=development yarn install
 
       - name: Check if .prettierrc.js file exists
         id: prettier-config-js
@@ -49,13 +47,13 @@ jobs:
         uses: actionsx/prettier@v3
         if: ${{ steps.prettier-config-js.outputs.files_exists == 'true' }}
         with:
-          args: --write .  --ignore-path ./.prettierignore --config ./.prettierrc.js
+          args: --write . --ignore-path ./.prettierignore --config ./.prettierrc.js
 
       - name: Run prettier with .prettierrc.json configuration
         uses: actionsx/prettier@v3
         if: ${{ steps.prettier-config-json.outputs.files_exists == 'true' }}
         with:
-          args: --write .  --ignore-path ./.prettierignore --config ./.prettierrc.json
+          args: --write . --ignore-path ./.prettierignore --config ./.prettierrc.json
 
       - name: Run prettier without any configuration files
         uses: actionsx/prettier@v3

--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -31,6 +31,15 @@ jobs:
         if: ${{ inputs.prettierPlugins }}
         uses: Andrews-McMeel-Universal/cache-yarn-install@v1
 
+      - name: Set prettier plugin arguments
+        id: prettier-plugins
+        if: ${{ inputs.prettierPlugins }}
+        run: |
+          for PLUGIN in (${{ inputs.prettierPlugins }}); do
+            PRETTIER_PLUGINS="$PRETTIER_PLUGINS --plugin $PLUGIN"
+          done
+          echo "prettierPlugins=$PRETTIER_PLUGINS" >> $GITHUB_OUTPUT
+
       - name: Check if .prettierrc.js file exists
         id: prettier-config-js
         uses: andstor/file-existence-action@v2
@@ -47,13 +56,13 @@ jobs:
         uses: actionsx/prettier@v3
         if: ${{ steps.prettier-config-js.outputs.files_exists == 'true' }}
         with:
-          args: --write . --ignore-path ./.prettierignore --config ./.prettierrc.js
+          args: --write . --ignore-path ./.prettierignore --config ./.prettierrc.js ${{ steps.prettier-plugins.outputs.prettierPlugins }}
 
       - name: Run prettier with .prettierrc.json configuration
         uses: actionsx/prettier@v3
         if: ${{ steps.prettier-config-json.outputs.files_exists == 'true' }}
         with:
-          args: --write . --ignore-path ./.prettierignore --config ./.prettierrc.json
+          args: --write . --ignore-path ./.prettierignore --config ./.prettierrc.json ${{ steps.prettier-plugins.outputs.prettierPlugins }}
 
       - name: Run prettier without any configuration files
         uses: actionsx/prettier@v3

--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Run yarn install
         if: ${{ inputs.prettierPlugins }}
-        uses: Andrews-McMeel-Universal/cache-yarn-install@bug/DEVOPS-376/prettier-not-respecting-config-files-pt2
+        uses: Andrews-McMeel-Universal/cache-yarn-install@v1
 
       - name: Set prettier plugin arguments
         id: prettier-plugins
@@ -53,16 +53,12 @@ jobs:
           files: ".prettierrc.json"
 
       - name: Run prettier with .prettierrc.js configuration
-        uses: actionsx/prettier@v3
         if: ${{ steps.prettier-config-js.outputs.files_exists == 'true' }}
-        with:
-          args: --write . --ignore-path ./.prettierignore --config ./.prettierrc.js ${{ steps.prettier-plugins.outputs.prettierPlugins }}
+        run: yarn run prettier --write . --ignore-path ./.prettierignore --config ./.prettierrc.js ${{ steps.prettier-plugins.outputs.prettierPlugins }}
 
       - name: Run prettier with .prettierrc.json configuration
-        uses: actionsx/prettier@v3
         if: ${{ steps.prettier-config-json.outputs.files_exists == 'true' }}
-        with:
-          args: --write . --ignore-path ./.prettierignore --config ./.prettierrc.json ${{ steps.prettier-plugins.outputs.prettierPlugins }}
+        run: yarn run prettier --write . --ignore-path ./.prettierignore --config ./.prettierrc.json ${{ steps.prettier-plugins.outputs.prettierPlugins }}
 
       - name: Run prettier without any configuration files
         uses: actionsx/prettier@v3

--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -74,7 +74,8 @@ jobs:
         if: ${{ steps.prettier-config-js.outputs.files_exists != 'true' && steps.prettier-config-json.outputs.files_exists != 'true' }}
         uses: creyD/prettier_action@v4.3
         with:
-          prettier_options: --write . --ignore-path ./.prettierignore
+          prettier_options: --write . --ignore-path ./.prettierignore ${{ steps.prettier-plugins.outputs.prettierPlugins }}
+          prettier_plugins: ${{ inputs.prettierPlugins }}
           commit_message: "[Simple Linter] Apply prettier changes"
           only_changed: true
 

--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -29,7 +29,9 @@ jobs:
 
       - name: Install prettier modules
         if: ${{ inputs.prettierPlugins }}
-        run: yarn add ${{ inputs.prettierPlugins }}
+        env:
+          NODE_ENV: development
+        run: yarn install
 
       - name: Check if .prettierrc.js file exists
         id: prettier-config-js

--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -54,11 +54,21 @@ jobs:
 
       - name: Run prettier with .prettierrc.js configuration
         if: ${{ steps.prettier-config-js.outputs.files_exists == 'true' }}
-        run: yarn run prettier --write . --ignore-path ./.prettierignore --config ./.prettierrc.js ${{ steps.prettier-plugins.outputs.prettierPlugins }}
+        uses: creyD/prettier_action@v4.3
+        with:
+          prettier_options: --write . --ignore-path ./.prettierignore --config ./.prettierrc.js ${{ steps.prettier-plugins.outputs.prettierPlugins }}
+          prettier_plugins: ${{ inputs.prettierPlugins }}
+          commit_message: "[Simple Linter] Apply prettier changes"
+          only_changed: true
 
       - name: Run prettier with .prettierrc.json configuration
         if: ${{ steps.prettier-config-json.outputs.files_exists == 'true' }}
-        run: yarn run prettier --write . --ignore-path ./.prettierignore --config ./.prettierrc.json ${{ steps.prettier-plugins.outputs.prettierPlugins }}
+        uses: creyD/prettier_action@v4.3
+        with:
+          prettier_options: --write . --ignore-path ./.prettierignore --config ./.prettierrc.json ${{ steps.prettier-plugins.outputs.prettierPlugins }}
+          prettier_plugins: ${{ inputs.prettierPlugins }}
+          commit_message: "[Simple Linter] Apply prettier changes"
+          only_changed: true
 
       - name: Run prettier without any configuration files
         uses: actionsx/prettier@v3

--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -36,7 +36,7 @@ jobs:
         if: ${{ inputs.prettierPlugins }}
         run: |
           PLUGINS=(${{ inputs.prettierPlugins }})
-          for PLUGIN in ${PLUGINS[*]}; do
+          for PLUGIN in "${PLUGINS[@]}"; do
             PRETTIER_PLUGINS="$PRETTIER_PLUGINS --plugin $PLUGIN"
           done
           echo "prettierPlugins=$PRETTIER_PLUGINS" >> $GITHUB_OUTPUT

--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -31,6 +31,15 @@ jobs:
         if: ${{ inputs.prettierPlugins }}
         uses: Andrews-McMeel-Universal/cache-yarn-install@v1
 
+      - name: Set prettier plugin arguments
+        id: prettier-plugins
+        if: ${{ inputs.prettierPlugins }}
+        run: |
+          for PLUGIN in ${{ inputs.prettierPlugins }}; do
+            PRETTIER_PLUGINS="$PRETTIER_PLUGINS --plugin $PLUGIN"
+          done
+          echo "prettierPlugins=$PRETTIER_PLUGINS" >> $GITHUB_OUTPUT
+
       - name: Check if .prettierrc.js file exists
         id: prettier-config-js
         uses: andstor/file-existence-action@v2
@@ -47,7 +56,7 @@ jobs:
         if: ${{ steps.prettier-config-js.outputs.files_exists == 'true' }}
         uses: creyD/prettier_action@v4.3
         with:
-          prettier_options: --write . --ignore-path ./.prettierignore --config ./.prettierrc.js
+          prettier_options: --write . --ignore-path ./.prettierignore --config ./.prettierrc.js ${{ steps.prettier-plugins.outputs.prettierPlugins }}
           prettier_plugins: ${{ inputs.prettierPlugins }}
           commit_message: "[Simple Linter] Apply prettier changes"
           only_changed: true
@@ -56,7 +65,7 @@ jobs:
         if: ${{ steps.prettier-config-json.outputs.files_exists == 'true' }}
         uses: creyD/prettier_action@v4.3
         with:
-          prettier_options: --write . --ignore-path ./.prettierignore --config ./.prettierrc.json
+          prettier_options: --write . --ignore-path ./.prettierignore --config ./.prettierrc.json ${{ steps.prettier-plugins.outputs.prettierPlugins }}
           prettier_plugins: ${{ inputs.prettierPlugins }}
           commit_message: "[Simple Linter] Apply prettier changes"
           only_changed: true

--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -35,7 +35,8 @@ jobs:
         id: prettier-plugins
         if: ${{ inputs.prettierPlugins }}
         run: |
-          for PLUGIN in ${{ inputs.prettierPlugins }}; do
+          PLUGINS=(${{ inputs.prettierPlugins }})
+          for PLUGIN in ${PLUGINS[*]}; do
             PRETTIER_PLUGINS="$PRETTIER_PLUGINS --plugin $PLUGIN"
           done
           echo "prettierPlugins=$PRETTIER_PLUGINS" >> $GITHUB_OUTPUT

--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -27,14 +27,9 @@ jobs:
           token: ${{ secrets.PAT_ACTION_CI }}
           ref: ${{ github.head_ref }}
 
-      - name: Set prettier plugin arguments
-        id: prettier-plugins
+      - name: Run yarn install
         if: ${{ inputs.prettierPlugins }}
-        run: |
-          for PLUGIN in ${{ inputs.prettierPlugins }}; do
-            PRETTIER_PLUGINS="$PRETTIER_PLUGINS --plugin $PLUGIN"
-          done
-          echo "prettierPlugins=$PRETTIER_PLUGINS" >> $GITHUB_OUTPUT
+        uses: Andrews-McMeel-Universal/cache-yarn-install@v1
 
       - name: Check if .prettierrc.js file exists
         id: prettier-config-js
@@ -52,7 +47,7 @@ jobs:
         if: ${{ steps.prettier-config-js.outputs.files_exists == 'true' }}
         uses: creyD/prettier_action@v4.3
         with:
-          prettier_options: --write . --ignore-path ./.prettierignore --config ./.prettierrc.js ${{ steps.prettier-plugins.outputs.prettierPlugins }}
+          prettier_options: --write . --ignore-path ./.prettierignore --config ./.prettierrc.js
           prettier_plugins: ${{ inputs.prettierPlugins }}
           commit_message: "[Simple Linter] Apply prettier changes"
           only_changed: true
@@ -61,7 +56,7 @@ jobs:
         if: ${{ steps.prettier-config-json.outputs.files_exists == 'true' }}
         uses: creyD/prettier_action@v4.3
         with:
-          prettier_options: --write . --ignore-path ./.prettierignore --config ./.prettierrc.json ${{ steps.prettier-plugins.outputs.prettierPlugins }}
+          prettier_options: --write . --ignore-path ./.prettierignore --config ./.prettierrc.json
           prettier_plugins: ${{ inputs.prettierPlugins }}
           commit_message: "[Simple Linter] Apply prettier changes"
           only_changed: true

--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -35,7 +35,7 @@ jobs:
         id: prettier-plugins
         if: ${{ inputs.prettierPlugins }}
         run: |
-          for PLUGIN in (${{ inputs.prettierPlugins }}); do
+          for PLUGIN in ${{ inputs.prettierPlugins }}; do
             PRETTIER_PLUGINS="$PRETTIER_PLUGINS --plugin $PLUGIN"
           done
           echo "prettierPlugins=$PRETTIER_PLUGINS" >> $GITHUB_OUTPUT

--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Run yarn install
         if: ${{ inputs.prettierPlugins }}
-        uses: Andrews-McMeel-Universal/cache-yarn-install@v1
+        uses: Andrews-McMeel-Universal/cache-yarn-install@bug/DEVOPS-376/prettier-not-respecting-config-files-pt2
 
       - name: Set prettier plugin arguments
         id: prettier-plugins

--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -43,23 +43,24 @@ jobs:
         with:
           files: ".prettierrc.json"
 
-      - name: Run prettier with configuration files
-        uses: creyD/prettier_action@v4.3
-        if: ${{ steps.prettier-config-js.outputs.files_exists == 'true' || steps.prettier-config-json.outputs.files_exists == 'true' }}
+      - uses: actionsx/prettier@v3
+        if: ${{ steps.prettier-config-js.outputs.files_exists == 'true' }}
         with:
-          prettier_options: --write . --config ./.prettierrc.js --config ./.prettierrc.json --ignore-path ./.prettierignore
-          commit_message: "[Simple Linter] Apply prettier changes"
-          github_token: ${{ secrets.PAT_ACTION_CI }}
-          only_changed: true
+          args: --write .  --ignore-path ./.prettierignore --config ./.prettierrc.js
 
-      - name: Run prettier without configuration files
-        uses: creyD/prettier_action@v4.3
-        if: ${{ steps.prettier-config-js.outputs.files_exists != 'true' && steps.prettier-config-json.outputs.files_exists != 'true' }}
+      - uses: actionsx/prettier@v3
+        if: ${{ steps.prettier-config-json.outputs.files_exists == 'true' }}
         with:
-          prettier_options: --write . --ignore-path ./.prettierignore
+          args: --write .  --ignore-path ./.prettierignore --config ./.prettierrc.json
+
+      - uses: actionsx/prettier@v3
+        if: ${{ steps.prettier-config-js.outputs.files_exists != 'true' || steps.prettier-config-json.outputs.files_exists != 'true' }}
+        with:
+          args: --write . --ignore-path ./.prettierignore
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
           commit_message: "[Simple Linter] Apply prettier changes"
-          github_token: ${{ secrets.PAT_ACTION_CI }}
-          only_changed: true
 
   lint-workflows:
     name: Workflow linter

--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -43,18 +43,21 @@ jobs:
         with:
           files: ".prettierrc.json"
 
-      - uses: actionsx/prettier@v3
+      - name: Run prettier with .prettierrc.js configuration
+        uses: actionsx/prettier@v3
         if: ${{ steps.prettier-config-js.outputs.files_exists == 'true' }}
         with:
           args: --write .  --ignore-path ./.prettierignore --config ./.prettierrc.js
 
-      - uses: actionsx/prettier@v3
+      - name: Run prettier with .prettierrc.json configuration
+        uses: actionsx/prettier@v3
         if: ${{ steps.prettier-config-json.outputs.files_exists == 'true' }}
         with:
           args: --write .  --ignore-path ./.prettierignore --config ./.prettierrc.json
 
-      - uses: actionsx/prettier@v3
-        if: ${{ steps.prettier-config-js.outputs.files_exists != 'true' || steps.prettier-config-json.outputs.files_exists != 'true' }}
+      - name: Run prettier without any configuration files
+        uses: actionsx/prettier@v3
+        if: ${{ steps.prettier-config-js.outputs.files_exists != 'true' && steps.prettier-config-json.outputs.files_exists != 'true' }}
         with:
           args: --write . --ignore-path ./.prettierignore
 

--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -71,14 +71,12 @@ jobs:
           only_changed: true
 
       - name: Run prettier without any configuration files
-        uses: actionsx/prettier@v3
         if: ${{ steps.prettier-config-js.outputs.files_exists != 'true' && steps.prettier-config-json.outputs.files_exists != 'true' }}
+        uses: creyD/prettier_action@v4.3
         with:
-          args: --write . --ignore-path ./.prettierignore
-
-      - uses: stefanzweifel/git-auto-commit-action@v4
-        with:
+          prettier_options: --write . --ignore-path ./.prettierignore
           commit_message: "[Simple Linter] Apply prettier changes"
+          only_changed: true
 
   lint-workflows:
     name: Workflow linter

--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -27,9 +27,9 @@ jobs:
           token: ${{ secrets.PAT_ACTION_CI }}
           ref: ${{ github.head_ref }}
 
-      - name: Install prettier modules
+      - name: Run yarn install
         if: ${{ inputs.prettierPlugins }}
-        run: NODE_ENV=development yarn install
+        uses: Andrews-McMeel-Universal/cache-yarn-install@v1
 
       - name: Check if .prettierrc.js file exists
         id: prettier-config-js

--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           files: ".prettierrc.js"
 
-      - name: Check if .prettierrc.json files exists
+      - name: Check if .prettierrc.json file exists
         id: prettier-config-json
         uses: andstor/file-existence-action@v2
         with:
@@ -48,17 +48,15 @@ jobs:
         if: ${{ steps.prettier-config-js.outputs.files_exists == 'true' || steps.prettier-config-json.outputs.files_exists == 'true' }}
         with:
           prettier_options: --write . --config ./.prettierrc.js --config ./.prettierrc.json --ignore-path ./.prettierignore
-          prettier_plugins: ${{ inputs.prettierPlugins }}
           commit_message: "[Simple Linter] Apply prettier changes"
           github_token: ${{ secrets.PAT_ACTION_CI }}
           only_changed: true
 
-      - name: Run prettier
+      - name: Run prettier without configuration files
         uses: creyD/prettier_action@v4.3
         if: ${{ steps.prettier-config-js.outputs.files_exists != 'true' && steps.prettier-config-json.outputs.files_exists != 'true' }}
         with:
           prettier_options: --write . --ignore-path ./.prettierignore
-          prettier_plugins: ${{ inputs.prettierPlugins }}
           commit_message: "[Simple Linter] Apply prettier changes"
           github_token: ${{ secrets.PAT_ACTION_CI }}
           only_changed: true


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-376" title="DEVOPS-376" target="_blank">DEVOPS-376</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Prettier not respecting config files in TPS UI</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://amuniversal.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Run [Andrews-McMeel-Universal/cache-yarn-install](https://github.com/Andrews-McMeel-Universal/cache-yarn-install) action instead of `yarn add` or `yarn install`
- Pass in `--plugin [PLUGIN]` arguments based off plugins referenced in `inputs.prettierPlugins` to prettier action

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with your Jira issue key -->

- Jira Issue: DEVOPS-376
- Testing environment: [![✅ Linters](https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/actions/workflows/linters.yml/badge.svg?branch=bug%2FDEVOPS-376%2Fprettier-not-respecting-config-files-pt2)](https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/actions/workflows/linters.yml)
