### PR TITLE
[DEVOPS-453] Fix image refs to use GitHub SHAs

### DIFF
--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -191,16 +191,17 @@ jobs:
           contentTypes: BuildArg Env
 
       - name: Build Docker Image
-        run: docker build ${{ steps.get-envs.outputs.buildArguments }} -t "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.event.release.tag_name || github.sha }}" ${{ inputs.dockerFilePath }}
+        run: docker build ${{ steps.get-envs.outputs.buildArguments }} -t "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.sha }}" ${{ inputs.dockerFilePath }}
 
       - name: Tag Docker Image
         run: |
           if [[ "${{ inputs.environment }}" == "production" ]] ; then
-            docker tag "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.event.release.tag_name || github.sha }}" "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:latest"
+            docker tag "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.sha }}" "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:latest"
           fi
-          if [[ "${{ github.event.release.tag_name || github.sha }}" == "${{ github.event.release.tag_name }}" ]]; then
+          if [[ "${{ github.event.release.tag_name }}" != "" ]]; then
+            docker tag "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.sha }}" "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.event.release.tag_name }}"
             MAJOR_RELEASE=$(echo "${{ github.event.release.tag_name }}" | cut -d "." -f 1)
-            docker tag "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.event.release.tag_name || github.sha }}" "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${MAJOR_RELEASE}"
+            docker tag "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.sha }}" "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${MAJOR_RELEASE}"
           fi
 
       - name: Login to Azure Container Registry
@@ -309,7 +310,7 @@ jobs:
           overrideFiles: ./values-override.yaml
           overrides: |
             image.repository:${{ secrets.registryHostName }}/${{ github.event.repository.name }}
-            image.tag:${{ github.event.release.tag_name || github.sha }}
+            image.tag:${{ github.sha }}
             ingress.host:${{ needs.build.outputs.ingress }}
             autoscaling.maxReplicas:${{ inputs.maximumReplicas }}
 
@@ -379,7 +380,7 @@ jobs:
           namespace: ${{ steps.namespace.outputs.namespace }}
           manifests: ${{ steps.bake.outputs.manifestsBundle }}
           images: |
-            "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.event.release.tag_name || github.sha }}"
+            "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.sha }}"
           imagepullsecrets: |
             "${{ needs.build.outputs.imagePullSecret }}"
           pull-images: false


### PR DESCRIPTION
<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-453" title="DEVOPS-453" target="_blank">DEVOPS-453</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Restarting Docker builds in staging leads to pods starting with production image</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://amuniversal.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Fix image refs to use GitHub SHAs by default rather than tag names

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-453
