### PR TITLE
[DEVOPS-457] Lock deployed image tags so that we can enable image retention

### DIFF
--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -412,7 +412,7 @@ jobs:
       - name: Disable write access for newly deployed image
         run: |
           IMAGE_MANIFEST=$(az acr repository show --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}:${{ github.sha }}" --query "digest" -o tsv)
-          az acr repository update --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}:${IMAGE_MANIFEST}" --delete-enabled false --write-enabled false
+          az acr repository update --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}@${IMAGE_MANIFEST}" --delete-enabled false --write-enabled false
 
       - name: Create or Update Public DNS Record
         id: dns

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -202,7 +202,7 @@ jobs:
           PREVIOUS_MANIFEST=$(az acr repository show --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}:${{ inputs.environment }}" --query "digest" -o tsv)
           if [[ -n "$PREVIOUS_MANIFEST" ]]; then
             echo "Unlocking previous manifest: ${PREVIOUS_MANIFEST}"
-            az acr repository update --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}:${PREVIOUS_MANIFEST}" --delete-enabled true --write-enabled true
+            az acr repository update --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}@${PREVIOUS_MANIFEST}" --delete-enabled true --write-enabled true
           fi
 
       - name: Build Docker Image

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -411,7 +411,8 @@ jobs:
 
       - name: Disable write access for newly deployed image
         run: |
-          az acr repository update --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}:${{ github.sha }}" --delete-enabled false --write-enabled false
+          IMAGE_MANIFEST=$(az acr repository show --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}:${{ github.sha }}" --query "digest" -o tsv)
+          az acr repository update --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}:${IMAGE_MANIFEST}" --delete-enabled false --write-enabled false
 
       - name: Create or Update Public DNS Record
         id: dns

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -403,7 +403,11 @@ jobs:
 
       - name: Untag previous ACR image
         run: |
-          az acr repository untag --name "${{ secrets.registryHostName }}" --image "${{ steps.get-current-image.outputs.currentImage }}"
+          if [[ "${{ steps.get-current-image.outputs.currentImage }}" != "${{ github.event.repository.name }}:${{ github.sha }}" ]]; then
+            az acr repository untag --name "${{ secrets.registryHostName }}" --image "${{ steps.get-current-image.outputs.currentImage }}"
+          else
+            echo "Deployment image is the same as the current image. Skipping untagging."
+          fi
 
       - name: Disable write access for newly deployed image
         run: |

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -209,26 +209,24 @@ jobs:
 
       - name: Build Docker Image
         run: |
-          REGISTRY_REPOSITORY="${{ secrets.registryHostName }}/${{ github.event.repository.name }}"
-          IMAGE_NAME="${REGISTRY_REPOSITORY}:${{ github.sha }}"
+          IMAGE_NAME="${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.sha }}"
           docker build ${{ steps.get-envs.outputs.buildArguments }} -t "${IMAGE_NAME}" ${{ inputs.dockerFilePath }}
 
       - name: Tag Docker Image
         run: |
-          REGISTRY_REPOSITORY="${{ secrets.registryHostName }}/${{ github.event.repository.name }}"
           if [[ "${{ inputs.environment }}" == "production" ]] ; then
-            docker tag "${IMAGE_NAME}" "${REGISTRY_REPOSITORY}:latest"
-            docker tag "${IMAGE_NAME}" "${REGISTRY_REPOSITORY}:stable"
+            docker tag "${IMAGE_NAME}" "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:latest"
+            docker tag "${IMAGE_NAME}" "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:stable"
           fi
           if [[ "${{ github.event.release.tag_name }}" != "" ]]; then
-            docker tag "${IMAGE_NAME}" "${REGISTRY_REPOSITORY}:${{ github.event.release.tag_name }}"
+            docker tag "${IMAGE_NAME}" "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.event.release.tag_name }}"
             MAJOR_RELEASE=$(echo "${{ github.event.release.tag_name }}" | cut -d "." -f 1)
-            docker tag "${IMAGE_NAME}" "${REGISTRY_REPOSITORY}:${MAJOR_RELEASE}"
+            docker tag "${IMAGE_NAME}" "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${MAJOR_RELEASE}"
           fi
-          docker tag "${IMAGE_NAME}" "${REGISTRY_REPOSITORY}:${{ inputs.environment }}"
+          docker tag "${IMAGE_NAME}" "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ inputs.environment }}"
 
       - name: Push Docker Image
-        run: docker push -a "${REGISTRY_REPOSITORY}"
+        run: docker push -a "${{ secrets.registryHostName }}/${{ github.event.repository.name }}"
     outputs:
       appName: ${{ env.appName }}
       appVersion: ${{ env.appVersion }}

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -197,6 +197,10 @@ jobs:
           username: ${{ secrets.registryUserName }}
           password: ${{ secrets.registryPassword }}
 
+      - name: Unlock previous ACR image
+        run: |
+          az acr repository update --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}:${{ inputs.environment }}" --delete-enabled true --write-enabled true
+
       - name: Build Docker Image
         run: docker build ${{ steps.get-envs.outputs.buildArguments }} -t "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.sha }}" ${{ inputs.dockerFilePath }}
 
@@ -204,12 +208,14 @@ jobs:
         run: |
           if [[ "${{ inputs.environment }}" == "production" ]] ; then
             docker tag "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.sha }}" "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:latest"
+            docker tag "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.sha }}" "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:stable"
           fi
           if [[ "${{ github.event.release.tag_name }}" != "" ]]; then
             docker tag "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.sha }}" "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.event.release.tag_name }}"
             MAJOR_RELEASE=$(echo "${{ github.event.release.tag_name }}" | cut -d "." -f 1)
             docker tag "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.sha }}" "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${MAJOR_RELEASE}"
           fi
+          docker tag "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.sha }}" "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ inputs.environment }}"
 
       - name: Push Docker Image
         run: docker push -a "${{ secrets.registryHostName }}/${{ github.event.repository.name }}"
@@ -373,6 +379,12 @@ jobs:
           container-registry-password: ${{ secrets.registryPassword  }}
           secret-name: "${{ needs.build.outputs.imagePullSecret }}"
 
+      - name: Get current image tag used in deployment
+        id: get-current-image
+        run: |
+          CURRENT_IMAGE=$(kubectl get deployment "${{ needs.build.outputs.appName }}" -n "${{ steps.namespace.outputs.namespace }}" -o=jsonpath='{$.spec.template.spec.containers[:1].image}' | awk -F '/' '{print $2}')
+          echo "currentImage=${CURRENT_IMAGE}" >> $GITHUB_OUTPUT
+
       - name: Deploy to Azure Kubernetes Service
         timeout-minutes: ${{ inputs.deploymentTimeout }}
         uses: Azure/k8s-deploy@v4
@@ -384,6 +396,14 @@ jobs:
           imagepullsecrets: |
             "${{ needs.build.outputs.imagePullSecret }}"
           pull-images: false
+
+      - name: Untag previous ACR image
+        run: |
+          az acr repository untag --name "${{ secrets.registryHostName }}" --image "${{ steps.get-current-image.outputs.currentImage }}"
+
+      - name: Disable write access for newly deployed image
+        run: |
+          az acr repository update --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}:${{ github.sha }}" --delete-enabled false --write-enabled false
 
       - name: Create or Update Public DNS Record
         id: dns

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -215,6 +215,7 @@ jobs:
 
       - name: Tag Docker Image
         run: |
+          REGISTRY_REPOSITORY="${{ secrets.registryHostName }}/${{ github.event.repository.name }}"
           if [[ "${{ inputs.environment }}" == "production" ]] ; then
             docker tag "${IMAGE_NAME}" "${REGISTRY_REPOSITORY}:latest"
             docker tag "${IMAGE_NAME}" "${REGISTRY_REPOSITORY}:stable"

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -208,23 +208,26 @@ jobs:
           fi
 
       - name: Build Docker Image
-        run: docker build ${{ steps.get-envs.outputs.buildArguments }} -t "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.sha }}" ${{ inputs.dockerFilePath }}
+        run: |
+          REGISTRY_REPOSITORY="${{ secrets.registryHostName }}/${{ github.event.repository.name }}"
+          IMAGE_NAME="${REGISTRY_REPOSITORY}:${{ github.sha }}"
+          docker build ${{ steps.get-envs.outputs.buildArguments }} -t "${IMAGE_NAME}" ${{ inputs.dockerFilePath }}
 
       - name: Tag Docker Image
         run: |
           if [[ "${{ inputs.environment }}" == "production" ]] ; then
-            docker tag "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.sha }}" "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:latest"
-            docker tag "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.sha }}" "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:stable"
+            docker tag "${IMAGE_NAME}" "${REGISTRY_REPOSITORY}:latest"
+            docker tag "${IMAGE_NAME}" "${REGISTRY_REPOSITORY}:stable"
           fi
           if [[ "${{ github.event.release.tag_name }}" != "" ]]; then
-            docker tag "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.sha }}" "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.event.release.tag_name }}"
+            docker tag "${IMAGE_NAME}" "${REGISTRY_REPOSITORY}:${{ github.event.release.tag_name }}"
             MAJOR_RELEASE=$(echo "${{ github.event.release.tag_name }}" | cut -d "." -f 1)
-            docker tag "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.sha }}" "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${MAJOR_RELEASE}"
+            docker tag "${IMAGE_NAME}" "${REGISTRY_REPOSITORY}:${MAJOR_RELEASE}"
           fi
-          docker tag "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.sha }}" "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ inputs.environment }}"
+          docker tag "${IMAGE_NAME}" "${REGISTRY_REPOSITORY}:${{ inputs.environment }}"
 
       - name: Push Docker Image
-        run: docker push -a "${{ secrets.registryHostName }}/${{ github.event.repository.name }}"
+        run: docker push -a "${REGISTRY_REPOSITORY}"
     outputs:
       appName: ${{ env.appName }}
       appVersion: ${{ env.appVersion }}

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -209,21 +209,24 @@ jobs:
 
       - name: Build Docker Image
         run: |
-          IMAGE_NAME="${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.sha }}"
+          REGISTRY_REPO="${{ secrets.registryHostName }}/${{ github.event.repository.name }}"
+          IMAGE_NAME="${REGISTRY_REPO}:${{ github.sha }}"
           docker build ${{ steps.get-envs.outputs.buildArguments }} -t "${IMAGE_NAME}" ${{ inputs.dockerFilePath }}
 
       - name: Tag Docker Image
         run: |
+          REGISTRY_REPO="${{ secrets.registryHostName }}/${{ github.event.repository.name }}"
+          IMAGE_NAME="${REGISTRY_REPO}:${{ github.sha }}"
           if [[ "${{ inputs.environment }}" == "production" ]] ; then
-            docker tag "${IMAGE_NAME}" "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:latest"
-            docker tag "${IMAGE_NAME}" "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:stable"
+            docker tag "${IMAGE_NAME}" "${REGISTRY_REPO}:latest"
+            docker tag "${IMAGE_NAME}" "${REGISTRY_REPO}:stable"
           fi
           if [[ "${{ github.event.release.tag_name }}" != "" ]]; then
-            docker tag "${IMAGE_NAME}" "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.event.release.tag_name }}"
+            docker tag "${IMAGE_NAME}" "${REGISTRY_REPO}:${{ github.event.release.tag_name }}"
             MAJOR_RELEASE=$(echo "${{ github.event.release.tag_name }}" | cut -d "." -f 1)
-            docker tag "${IMAGE_NAME}" "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${MAJOR_RELEASE}"
+            docker tag "${IMAGE_NAME}" "${REGISTRY_REPO}:${MAJOR_RELEASE}"
           fi
-          docker tag "${IMAGE_NAME}" "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ inputs.environment }}"
+          docker tag "${IMAGE_NAME}" "${REGISTRY_REPO}:${{ inputs.environment }}"
 
       - name: Push Docker Image
         run: docker push -a "${{ secrets.registryHostName }}/${{ github.event.repository.name }}"

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -203,6 +203,8 @@ jobs:
           if [[ -n "$PREVIOUS_MANIFEST" ]]; then
             echo "Unlocking previous manifest: ${PREVIOUS_MANIFEST}"
             az acr repository update --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}@${PREVIOUS_MANIFEST}" --delete-enabled true --write-enabled true
+          else
+            echo "Previous manifest could not be found. Skipping unlocking."
           fi
 
       - name: Build Docker Image
@@ -387,6 +389,10 @@ jobs:
         id: get-current-image
         run: |
           CURRENT_IMAGE=$(kubectl get deployment "${{ needs.build.outputs.appName }}" -n "${{ steps.namespace.outputs.namespace }}" -o=jsonpath='{$.spec.template.spec.containers[:1].image}' | awk -F '/' '{print $2}')
+          if [ -z "${CURRENT_IMAGE}" ]; then
+            echo "Failed to get current image"
+            exit 1
+          fi
           echo "currentImage=${CURRENT_IMAGE}" >> $GITHUB_OUTPUT
 
       - name: Deploy to Azure Kubernetes Service
@@ -412,6 +418,10 @@ jobs:
       - name: Disable write access for newly deployed image
         run: |
           IMAGE_MANIFEST=$(az acr repository show --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}:${{ github.sha }}" --query "digest" -o tsv)
+          if [ -z "${IMAGE_MANIFEST}" ]; then
+            echo "Failed to get current image manifest"
+            exit 1
+          fi
           az acr repository update --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}@${IMAGE_MANIFEST}" --delete-enabled false --write-enabled false
 
       - name: Create or Update Public DNS Record

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -200,7 +200,10 @@ jobs:
       - name: Unlock previous ACR image
         run: |
           PREVIOUS_MANIFEST=$(az acr repository show --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}:${{ inputs.environment }}" --query "digest" -o tsv | awk -F ':' '{print $2}')
-          az acr repository update --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}:${PREVIOUS_MANIFEST}" --delete-enabled true --write-enabled true
+          if [[ -n "$PREVIOUS_MANIFEST" ]]; then
+            echo "Unlocking previous manifest: ${PREVIOUS_MANIFEST}"
+            az acr repository update --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}:${PREVIOUS_MANIFEST}" --delete-enabled true --write-enabled true
+          fi
 
       - name: Build Docker Image
         run: docker build ${{ steps.get-envs.outputs.buildArguments }} -t "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.sha }}" ${{ inputs.dockerFilePath }}

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -199,7 +199,8 @@ jobs:
 
       - name: Unlock previous ACR image
         run: |
-          az acr repository update --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}:${{ inputs.environment }}" --delete-enabled true --write-enabled true
+          PREVIOUS_MANIFEST=$(az acr repository show --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}:${{ inputs.environment }}" --query "digest" -o tsv | awk -F ':' '{print $2}')
+          az acr repository update --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}:${PREVIOUS_MANIFEST}" --delete-enabled true --write-enabled true
 
       - name: Build Docker Image
         run: docker build ${{ steps.get-envs.outputs.buildArguments }} -t "${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.sha }}" ${{ inputs.dockerFilePath }}

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -199,7 +199,7 @@ jobs:
 
       - name: Unlock previous ACR image
         run: |
-          PREVIOUS_MANIFEST=$(az acr repository show --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}:${{ inputs.environment }}" --query "digest" -o tsv | awk -F ':' '{print $2}')
+          PREVIOUS_MANIFEST=$(az acr repository show --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}:${{ inputs.environment }}" --query "digest" -o tsv)
           if [[ -n "$PREVIOUS_MANIFEST" ]]; then
             echo "Unlocking previous manifest: ${PREVIOUS_MANIFEST}"
             az acr repository update --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}:${PREVIOUS_MANIFEST}" --delete-enabled true --write-enabled true


### PR DESCRIPTION
<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Lock deployed image tags so that we can enable image retention in the Azure Container Registry and delete old tags/manifests that are taking up storage.
  - Before building/pushing the Docker image for the deploy (because we're trying to use the environment tag), set write/delete access on the last manifest associated with the environment.
  - Gets the current image that is deployed to the environment prior to pushing the new deployment so that we can then untag the associated manifest after the deployment is updated.
  - After a successful deploy (all previous steps would need to succeed to get to this point), disable write/delete access for the deployed manifest so that it doesn't get accidentally untagged/deleted by the retention policies or any other scripts.
- Added 'stable' tag to production Docker images.
- Added environment tags to Docker images.
- Added variables for `REGISTRY_REPO` and `IMAGE_NAME` to make steps more readable.

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-457
