### PR TITLE
[DEVOPS-457] Untag old deploy manifests

### DIFF
--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -420,7 +420,6 @@ jobs:
           if [[ -n "$PREVIOUS_MANIFEST" ]] && [[ "${{ steps.get-previous-image.outputs.previousImage }}" != "${{ github.event.repository.name }}:${{ github.sha }}" ]]; then
             echo "Unlocking previous manifest: ${PREVIOUS_MANIFEST}"
             az acr repository update --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}@${PREVIOUS_MANIFEST}" --delete-enabled true --write-enabled true
-            az acr repository untag --name "${{ secrets.registryHostName }}" --image "${{ steps.get-previous-image.outputs.previousImage }}"
             while read -r TAG; do
               SEMVER_REGEX="^[0-9]+\.[0-9]+\.[0-9]+$"
               if [[ ! "${TAG} =~ ${SEMVER_REGEX}" ]]; then

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -421,6 +421,15 @@ jobs:
             echo "Unlocking previous manifest: ${PREVIOUS_MANIFEST}"
             az acr repository update --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}@${PREVIOUS_MANIFEST}" --delete-enabled true --write-enabled true
             az acr repository untag --name "${{ secrets.registryHostName }}" --image "${{ steps.get-previous-image.outputs.previousImage }}"
+            while read -r TAG; do
+              SEMVER_REGEX="^[0-9]+\.[0-9]+\.[0-9]+$"
+              if [[ ! "${TAG} =~ ${SEMVER_REGEX}" ]]; then
+                echo "Untagging ${{ github.event.repository.name }}:${TAG}"
+                az acr repository untag --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}:${TAG}"
+              else
+                echo "Skipping untagging ${{ github.event.repository.name }}:${TAG}"
+              fi
+            done < <(az acr repository show --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}@${PREVIOUS_MANIFEST}" --query "tags" -o tsv)
           elif [[ "${{ steps.get-previous-image.outputs.previousImage }}" == "${{ github.event.repository.name }}:${{ github.sha }}" ]]; then
             echo "Deployment image is the same as the current image. Skipping unlocking."
           else


### PR DESCRIPTION
<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Untag all tags from previous deploys' manifests so that they're automatically deleted by the retention policies (if they're not associated with a tagged release)

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-457
