### PR TITLE
[UEXPRESS-1171] Add input to customize health check path in Docker CI workflow

### DIFF
--- a/.github/workflows/docker-ci.yaml
+++ b/.github/workflows/docker-ci.yaml
@@ -8,6 +8,11 @@ on:
         description: Environment to run CI checks in
         type: string
         default: development
+      healthCheckPath:
+        required: false
+        description: Path to health check endpoint
+        type: string
+        default: ${{ vars.APPLICATION_CI_HEALTHCHECK_PATH || '/' }}
     secrets:
       azureCredentials:
         required: false
@@ -78,8 +83,8 @@ jobs:
             sleep 15
             RESULT=$?
             if [ $RESULT -eq 0 ]; then
-              wget -O - -q "http://localhost:${{ env.dockerContainerPort }}" ||
-              curl "http://localhost:${{ env.dockerContainerPort }}"
+              wget -O - -q "http://localhost:${{ env.dockerContainerPort }}${{ inputs.healthCheckPath }}" ||
+              curl "http://localhost:${{ env.dockerContainerPort }}${{ inputs.healthCheckPath }}"
             else
               exit 1
             fi


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/UEXPRESS-1171" title="UEXPRESS-1171" target="_blank">UEXPRESS-1171</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>[DevOps] Add PR check to run docker build</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Maintenance" src="https://amuniversal.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10309?size=medium" />
        Maintenance
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Add input to customize health check path in Docker CI workflow

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: UEXPRESS-1171
