### PR TITLE
[DEVOPS-527] Add custom GitHub runner support to Ruby CI workflow

### DIFF
--- a/.github/workflows/ruby-ci.yaml
+++ b/.github/workflows/ruby-ci.yaml
@@ -21,6 +21,11 @@ on:
         type: string
         description: "Node.js version to install"
         default: "14"
+      GITHUB_RUNNER:
+        required: false
+        type: string
+        description: "The type of runner to use"
+        default: ${{ vars.CUSTOM_GITHUB_RUNNER || 'ubuntu-latest' }}
     secrets:
       AZURE_CREDENTIALS:
         required: true
@@ -32,7 +37,7 @@ jobs:
   build:
     name: Build and Test
     if: ${{ github.actor != 'dependabot[bot]' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.GITHUB_RUNNER }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-527" title="DEVOPS-527" target="_blank">DEVOPS-527</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Ruby Application CI workflows fail if the app requires gems.amuniversal.com access</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://amuniversal.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Add custom GitHub runner support to Ruby CI workflow

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-527
