### PR TITLE
[DEVOPS-541] Fix failed ephemeral deploys due to app name being too long

### DIFF
--- a/.github/workflows/ephemeral-deploy.yaml
+++ b/.github/workflows/ephemeral-deploy.yaml
@@ -100,7 +100,7 @@ jobs:
         id: checksum
         run: |
           CHECKSUM=$(echo -n '${{ inputs.repositoryName }}-${{ steps.jira-ticket.outputs.jiraTicketIdLc }}' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]//g' | sed 's/--/-/g' | sed 's/^-//;s/-$//' | cut -c1-31 | md5sum | cut -d' ' -f1 | sed 's/^\([0-9]\)/a\1/')
-          SHORT_CHECKSUM=${CHECKSUM:0:20}
+          SHORT_CHECKSUM=${CHECKSUM:0:18}
           CONTAINER_APP_NAME="${SHORT_CHECKSUM}-${{ steps.jira-ticket.outputs.jiraTicketIdLc }}"
           echo "containerAppName=${CONTAINER_APP_NAME}" >> $GITHUB_OUTPUT
     outputs:


### PR DESCRIPTION
<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Shorten checksum in Azure Function app name to 18 chars

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-541
