### PR TITLE
[DEVOPS-550] Default to DOTNET_VERSION repository variable in AzFunction Deploy Workflow

### DIFF
--- a/.github/workflows/azfunction-deploy.yaml
+++ b/.github/workflows/azfunction-deploy.yaml
@@ -8,7 +8,7 @@ on:
         type: string
         description: "Deploy Environment.  This is used to pull in and set the github environment. Can be development, staging, or production."
       DOTNET_VERSION:
-        default: "6.0.x"
+        default: ${{ vars.DOTNET_VERSION || '6.0.x' }}
         type: string
       AZURE_FUNCTIONAPP_NAME:
         type: string


### PR DESCRIPTION
<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-550" title="DEVOPS-550" target="_blank">DEVOPS-550</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Azure Function Deploy workflows not using DOTNET_VERSION repository variable</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://amuniversal.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

…ion Deploy workflow

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

Fixes this issue: https://github.com/Andrews-McMeel-Universal/subscription-webhook-manager_function/actions/runs/11132827010/job/30937802230
- Default to DOTNET_VERSION repository variable in AzFunction Deploy Workflow

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-550
