### PR TITLE
[DEVOPS-549] Automatically retrieve .NET version rather than defaulting to workflow input

### DIFF
--- a/.github/workflows/azfunction-deploy.yaml
+++ b/.github/workflows/azfunction-deploy.yaml
@@ -74,10 +74,16 @@ jobs:
         with:
           packages: jq
 
+      - name: Retrieve .NET version
+        id: dotnet-version
+        run: |
+          DOTNET_VERSION=$(grep -h '<TargetFramework>net' **/*.csproj | sed -E 's/.*<TargetFramework>net([0-9]+\.[0-9]+)<\/TargetFramework>.*/\1/' | sort -V | tail -n1)
+          echo "DOTNET_VERSION=${DOTNET_VERSION}" >> $GITHUB_OUTPUT
+
       - name: Setup application platform
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ inputs.DOTNET_VERSION }}
+          dotnet-version: ${{ inputs.DOTNET_VERSION || steps.dotnet-version.outputs.DOTNET_VERSION }}
 
       - name: Add AMU GitHub Packages nuget source
         if: ${{ env.PAT_ACTION_CI }}

--- a/.github/workflows/azfunction-deploy.yaml
+++ b/.github/workflows/azfunction-deploy.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Retrieve .NET version
         id: dotnet-version
         run: |
-          DOTNET_VERSION=$(grep -h '<TargetFramework>net' **/*.csproj | sed -E 's/.*<TargetFramework>net([0-9]+\.[0-9]+)<\/TargetFramework>.*/\1/' | sort -V | tail -n1)
+          DOTNET_VERSION=$(find . -name '*.csproj' -exec grep -h '<TargetFramework>net' {} + | sed -E 's/.*<TargetFramework>net([0-9]+\.[0-9]+)<\/TargetFramework>.*/\1/' | sort -V | tail -n1)
           echo "DOTNET_VERSION=${DOTNET_VERSION}" >> $GITHUB_OUTPUT
 
       - name: Setup application platform

--- a/.github/workflows/azfunction-deploy.yaml
+++ b/.github/workflows/azfunction-deploy.yaml
@@ -8,7 +8,7 @@ on:
         type: string
         description: "Deploy Environment.  This is used to pull in and set the github environment. Can be development, staging, or production."
       DOTNET_VERSION:
-        default: ${{ vars.DOTNET_VERSION || '6.0.x' }}
+        default: ${{ vars.DOTNET_VERSION }}
         type: string
       AZURE_FUNCTIONAPP_NAME:
         type: string

--- a/.github/workflows/dotnet-ci.yaml
+++ b/.github/workflows/dotnet-ci.yaml
@@ -15,7 +15,7 @@ on:
         required: false
         type: string
         description: ".NET SDK Version"
-        default: ${{ vars.DOTNET_VERSION || '6.0.x' }}
+        default: ${{ vars.DOTNET_VERSION }}
     secrets:
       AZURE_CREDENTIALS:
         required: true

--- a/.github/workflows/dotnet-ci.yaml
+++ b/.github/workflows/dotnet-ci.yaml
@@ -40,10 +40,16 @@ jobs:
           azurecredentials: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ inputs.environment }}
 
+      - name: Retrieve .NET version
+        id: dotnet-version
+        run: |
+          DOTNET_VERSION=$(grep -h '<TargetFramework>net' **/*.csproj | sed -E 's/.*<TargetFramework>net([0-9]+\.[0-9]+)<\/TargetFramework>.*/\1/' | sort -V | tail -n1)
+          echo "DOTNET_VERSION=${DOTNET_VERSION}" >> $GITHUB_OUTPUT
+
       - name: Setup application platform
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ inputs.DOTNET_VERSION }}
+          dotnet-version: ${{ inputs.DOTNET_VERSION || steps.dotnet-version.outputs.DOTNET_VERSION }}
 
       - name: Add AMU GitHub Packages nuget source
         run: |

--- a/.github/workflows/dotnet-ci.yaml
+++ b/.github/workflows/dotnet-ci.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Retrieve .NET version
         id: dotnet-version
         run: |
-          DOTNET_VERSION=$(grep -h '<TargetFramework>net' **/*.csproj | sed -E 's/.*<TargetFramework>net([0-9]+\.[0-9]+)<\/TargetFramework>.*/\1/' | sort -V | tail -n1)
+          DOTNET_VERSION=$(find . -name '*.csproj' -exec grep -h '<TargetFramework>net' {} + | sed -E 's/.*<TargetFramework>net([0-9]+\.[0-9]+)<\/TargetFramework>.*/\1/' | sort -V | tail -n1)
           echo "DOTNET_VERSION=${DOTNET_VERSION}" >> $GITHUB_OUTPUT
 
       - name: Setup application platform


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-549" title="DEVOPS-549" target="_blank">DEVOPS-549</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Automatically retrieve .NET SDK version from project files for .NET CI tests</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://amuniversal.atlassian.net/images/icons/issuetypes/story.png" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Automatically retrieve .NET version rather than defaulting to workflow input

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-549
