### PR TITLE
[DEVOPS-575] Add `apiSuffix` input to API deploy workflow

### DIFF
--- a/.github/workflows/update-azureapimanagement.yaml
+++ b/.github/workflows/update-azureapimanagement.yaml
@@ -22,6 +22,11 @@ on:
         type: string
         description: "API Management Product ID."
         default: ${{ vars.API_PRODUCT_ID || 'AZ-WebServices' }}
+      apiSuffix:
+        required: false
+        type: string
+        description: "API Suffix for the API URL."
+        default: ${{ vars.API_SUFFIX || 'true' }}
     secrets:
       azurePassword:
         required: false
@@ -103,7 +108,15 @@ jobs:
             $ApiSubscriptionRequired = $True
 
             # Generate API ID by appending "-api" to the repository name and replacing underscores with hyphens
-            $ApiId = ("${{ github.event.repository.name }}-api").Replace("_","-")
+
+            if (${{ inputs.apiSuffix }} -eq "true") {
+                $ApiSuffix = "-api"
+            }
+            else {
+                $ApiSuffix = ""
+            }
+
+            $ApiId = ("${{ github.event.repository.name }}$ApiSuffix").Replace("_","-")
 
             # Retrieve the resource group and service name based on the environment tag
             $ResourceGroup = (Get-AzResource -ResourceType Microsoft.ApiManagement/service -Tag @{"environment"="${{ inputs.environment }}"}).ResourceGroupName


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-575" title="DEVOPS-575" target="_blank">DEVOPS-575</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Uexpress Service API has "-api" suffix after deploys</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://amuniversal.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Add `apiSuffix` input to API deploy workflow so we can toggle it in cases where the service doesn't need it

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-575
