### PR TITLE
[DEVOPS-578] Fix "API already exists" errors

### DIFF
--- a/.github/workflows/update-azureapimanagement.yaml
+++ b/.github/workflows/update-azureapimanagement.yaml
@@ -167,7 +167,7 @@ jobs:
                     $SwaggerJSON | Out-File -FilePath $SwaggerJSONFile
 
                     # # Import the versioned API
-                    Import-AzApiManagementApi -Context $Context -SpecificationPath $SwaggerJSONFile -SpecificationFormat OpenApi -Path $ApiId -ApiId "$versionedApiId" -ApiVersion "v$version" -ApiVersionSetId $ApiVersionSet.Id
+                    Import-AzApiManagementApi -Context $Context -SpecificationPath $SwaggerJSONFile -SpecificationFormat OpenApi -Path $ApiId -ApiId "$versionedApiId" -ApiVersion "v$version" -ApiVersionSetId $ApiVersionSet.Id -Force
 
                     # Retrieve and update the API object
                     $Api = Get-AzApiManagementApi -Context $Context -ApiId "$versionedApiId"


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-578" title="DEVOPS-578" target="_blank">DEVOPS-578</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>API Deploy fails due to "already exists" conflict error</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://amuniversal.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Add -Force argument to Import command to fix "API.. already exists" errors

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-578
