### PR TITLE
[DEVOPS-579] Fix API suffix not getting added on by default

### DIFF
--- a/.github/workflows/update-azureapimanagement.yaml
+++ b/.github/workflows/update-azureapimanagement.yaml
@@ -108,14 +108,7 @@ jobs:
             $ApiSubscriptionRequired = $True
 
             # Generate API ID by appending "-api" to the repository name and replacing underscores with hyphens
-
-            if (${{ inputs.apiSuffix }} -eq "true") {
-                $ApiSuffix = "-api"
-            }
-            else {
-                $ApiSuffix = ""
-            }
-
+            $ApiSuffix = if ("${{ inputs.apiSuffix }}" -eq "true") { "-api" } else { "" }
             $ApiId = ("${{ github.event.repository.name }}$ApiSuffix").Replace("_","-")
 
             # Retrieve the resource group and service name based on the environment tag


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-579" title="DEVOPS-579" target="_blank">DEVOPS-579</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>API deploys are removing the "-api" suffix from the endpoints</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://amuniversal.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Fix API suffix not getting added on by default
  - Fixed quotes and simplified logic

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-579
