### PR TITLE
[DEVOPS-602] Fix .NET automatic version resolution

### DIFF
--- a/.github/workflows/dotnet-ci.yaml
+++ b/.github/workflows/dotnet-ci.yaml
@@ -43,13 +43,17 @@ jobs:
       - name: Retrieve .NET version
         id: dotnet-version
         run: |
-          DOTNET_VERSION=$(find . -name '*.csproj' -exec grep -h '<TargetFramework>net' {} + | sed -E 's/.*<TargetFramework>net([0-9]+\.[0-9]+)<\/TargetFramework>.*/\1/' | sort -V | tail -n1)
-          echo "DOTNET_VERSION=${DOTNET_VERSION}" >> $GITHUB_OUTPUT
+          if [[ -z "${{ inputs.DOTNET_VERSION }}" ]]; then
+            DOTNET_VERSION=$(find . -name '*.csproj' -exec grep -h '<TargetFramework>net' {} + | sed -E 's/.*<TargetFramework>net([0-9]+\.[0-9]+)<\/TargetFramework>.*/\1/' | sort -V | tail -n1)
+            echo "DOTNET_VERSION=${DOTNET_VERSION}" >> $GITHUB_OUTPUT
+          else
+            echo "DOTNET_VERSION=${{ inputs.DOTNET_VERSION }}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Setup application platform
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ inputs.DOTNET_VERSION || steps.dotnet-version.outputs.DOTNET_VERSION }}
+          dotnet-version: ${{ steps.dotnet-version.outputs.DOTNET_VERSION }}
 
       - name: Add AMU GitHub Packages nuget source
         run: |


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-602" title="DEVOPS-602" target="_blank">DEVOPS-602</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>.NET CI Workflow DOTNET_VERSION input not working</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://amuniversal.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>To Do</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Fix .NET automatic version resolution
  - Check if the `DOTNET_VERSION` input is null before trying to resolve the version automatically. Then use the output of that in the `actions/setup-dotnet` step.

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-602
