### PR TITLE
[DEVOPS-621] Fix `$ingressWhitelist` being set incorrectly

### DIFF
--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -312,14 +312,16 @@ jobs:
           $webAuthentication = "${{ inputs.webAuthentication }}" -replace '"', '' -replace "'", ""
           $environment = "${{ inputs.environment }}"
           $environmentIngress = "${{ inputs.environmentIngress }}" -replace '"', '' -replace "'", ""
-          $ingressWhitelist = "${{ inputs.ingressWhitelist }}"
           $adminIngressWhitelist = "${{ inputs.adminIngressWhitelist }}"
           $serviceIngressWhitelist = "${{ inputs.serviceIngressWhitelist }}"
 
           if ($appConfig.schemaVersion -eq "2") {
               foreach ($item in $appConfig.ingress) {
+                  # Reset ingress whitelist to input
+                  $ingressWhitelist = "${{ inputs.ingressWhitelist }}"
+
                   # Set ingress whitelist if not set
-                  if (($item.name -eq "ingress") -and ([string]::IsNullOrEmpty($ingressWhitelist))) {
+                  if (($item.name -eq "ingress") -and ($ingressWhitelist -notmatch '^(25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)\.((25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)\.){2}(25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)(/(3[0-2]|[1-2]?[0-9]))?$')) {
                       Write-Output "Ingress whitelist not set for $($item.name)"
                       if (($ingressWhitelist -eq "service") -or ($item.annotations."nginx.ingress.kubernetes.io/whitelist-source-range" -match "207.67.20.239,40.86.103.124,40.77.105.170")) {
                           # Use service whitelist
@@ -390,8 +392,11 @@ jobs:
           }
           else {
               foreach ($item in ($appConfig.GetEnumerator() | Where-Object { $_.Key -like "*ingress*" })) {
+                  # Reset ingress whitelist to input
+                  $ingressWhitelist = "${{ inputs.ingressWhitelist }}"
+
                   # Set ingress whitelist if not set
-                  if ([string]::IsNullOrEmpty($ingressWhitelist)) {
+                  if ($ingressWhitelist -notmatch '^(25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)\.((25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)\.){2}(25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)(/(3[0-2]|[1-2]?[0-9]))?$') {
                       Write-Output "Ingress whitelist not set for $($item.Key)"
                       if (($ingressWhitelist -eq "service") -or ($item.Value.annotations."nginx.ingress.kubernetes.io/whitelist-source-range" -match "207.67.20.239,40.86.103.124,40.77.105.170")) {
                           # Use service whitelist


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-621" title="DEVOPS-621" target="_blank">DEVOPS-621</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>ingressWhitelist is not being set properly during AKS deploys</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://amuniversal.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

Fix `$ingressWhitelist` being set incorrectly

Basically, the `$ingressWhitelist` variable was being set before the loop so anytime there was a modification made to it during one of the first items in the loop, it would apply those changes to the rest of the ingresses.

- Move setting the `$ingressWhitelist` variable to be inside the loop
- Check to make sure `$ingressWhitelist` includes valid CIDR notation before setting it to the default values.

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-621
