### PR TITLE
[DEVOPS-663] Add www redirect ingress via deploy workflows

### DIFF
--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -379,7 +379,7 @@ jobs:
                               name = "wwwredirect"
                               host = $item.host
                               paths = @{
-                                  path = "/(.*)"
+                                - path = "/(.*)"
                                   pathType = "Prefix"
                               }
                               ingressClassName = $item.ingressClassName

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -386,6 +386,7 @@ jobs:
                               name = "wwwredirect"
                               host = $item.host
                               path = "/(.*)"
+                              pathType = $item.pathType
                               ingressClassName = $item.ingressClassName
                               annotations = @{
                                   "nginx.ingress.kubernetes.io/rewrite-target" = "https://www.$($item.host)/$1"
@@ -431,6 +432,7 @@ jobs:
                       name = $item.name
                       host = $item.host
                       path = $item.path
+                      pathType = $item.pathType
                       ingressClassName = $item.ingressClassName
                       annotations = $item.annotations
                   }

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -376,15 +376,16 @@ jobs:
                       if (($item.redirectToWWW -eq $true) -and ($environment -eq "production") -and ($environmentIngress -ne "true")) {
                           # Add www redirect ingress
                           $updatedIngress += [PSCustomObject]@{
-                            name = "wwwredirect"
-                            host = $item.host
-                            paths = @{
-                                path = "/(.*)"
-                                pathType = "Prefix"
-                            }
-                            ingressClassName = $item.ingressClassName
-                            annotations = @{
-                                "nginx.ingress.kubernetes.io/rewrite-target" = "https://www.$($item.host)/$1"
+                              name = "wwwredirect"
+                              host = $item.host
+                              paths = @{
+                                  path = "/(.*)"
+                                  pathType = "Prefix"
+                              }
+                              ingressClassName = $item.ingressClassName
+                              annotations = @{
+                                  "nginx.ingress.kubernetes.io/rewrite-target" = "https://www.$($item.host)/$1"
+                              }
                           }
 
                           Write-Output "Adding www to $($item.name) host"

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -695,7 +695,7 @@ jobs:
           echo "aksIngress=${AKS_INGRESS}" >> $GITHUB_OUTPUT
 
           # Add www ingress if needed
-          WWWINGRESS="${{ needs.build.outputs.wwwIngress }}"
+          WWWINGRESS="${${{ needs.build.outputs.wwwIngress }},,}"
           if [ "${WWWINGRESS}" == "true" ]; then
             INGRESSES=("www.${{ needs.build.outputs.dnsSubDomain }}.${{ needs.build.outputs.domainName }}" "${{ needs.build.outputs.dnsSubDomain }}.${{ needs.build.outputs.domainName }}")
           else

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -385,12 +385,7 @@ jobs:
                           $updatedIngress += [PSCustomObject]@{
                               name = "wwwredirect"
                               host = $item.host
-                              paths = @(
-                                  @{
-                                      path = "/(.*)"
-                                      pathType = "Prefix"
-                                  }
-                              )
+                              path = "/(.*)"
                               ingressClassName = $item.ingressClassName
                               annotations = @{
                                   "nginx.ingress.kubernetes.io/rewrite-target" = "https://www.$($item.host)/$1"
@@ -435,7 +430,7 @@ jobs:
                   $updatedIngress += [PSCustomObject]@{
                       name = $item.name
                       host = $item.host
-                      paths = $item.paths
+                      path = $item.path
                       ingressClassName = $item.ingressClassName
                       annotations = $item.annotations
                   }

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -695,7 +695,7 @@ jobs:
           echo "aksIngress=${AKS_INGRESS}" >> $GITHUB_OUTPUT
 
           # Add www ingress if needed
-          WWWINGRESS="${${{ needs.build.outputs.wwwIngress }},,}"
+          WWWINGRESS=$(echo "${{ needs.build.outputs.wwwIngress }}" | tr '[:upper:]' '[:lower:]')
           if [ "${WWWINGRESS}" == "true" ]; then
             INGRESSES=("www.${{ needs.build.outputs.dnsSubDomain }}.${{ needs.build.outputs.domainName }}" "${{ needs.build.outputs.dnsSubDomain }}.${{ needs.build.outputs.domainName }}")
           else

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -213,6 +213,7 @@ jobs:
           Write-Output "dnsSubDomain=$dnsSubDomain" >> $env:GITHUB_ENV
           Write-Output "ingress=$ingress"
           Write-Output "ingress=$ingress" >> $env:GITHUB_ENV
+          Write-Output "wwwIngress=$wwwIngress"
           Write-Output "wwwIngress=$wwwIngress" >> $env:GITHUB_ENV
 
       - name: Generate .env file from Azure Key Vaults
@@ -694,7 +695,7 @@ jobs:
           echo "aksIngress=${AKS_INGRESS}" >> $GITHUB_OUTPUT
 
           # Add www ingress if needed
-          WWWINGRESS = "${{ needs.build.outputs.wwwIngress }}"
+          WWWINGRESS="${{ needs.build.outputs.wwwIngress }}"
           if [ "${WWWINGRESS}" == "true" ]; then
             INGRESSES=("www.${{ needs.build.outputs.dnsSubDomain }}.${{ needs.build.outputs.domainName }}" "${{ needs.build.outputs.dnsSubDomain }}.${{ needs.build.outputs.domainName }}")
           else

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -697,15 +697,15 @@ jobs:
           # Add www ingress if needed
           WWWINGRESS=$(echo "${{ needs.build.outputs.wwwIngress }}" | tr '[:upper:]' '[:lower:]')
           if [ "${WWWINGRESS}" == "true" ]; then
-            INGRESSES=("www.${{ needs.build.outputs.dnsSubDomain }}.${{ needs.build.outputs.domainName }}" "${{ needs.build.outputs.dnsSubDomain }}.${{ needs.build.outputs.domainName }}")
+            INGRESSES=("www.${{ needs.build.outputs.dnsSubDomain }}" "${{ needs.build.outputs.dnsSubDomain }}")
           else
-            INGRESSES=("${{ needs.build.outputs.dnsSubDomain }}.${{ needs.build.outputs.domainName }}")
+            INGRESSES=("${{ needs.build.outputs.dnsSubDomain }}")
           fi
 
           # Update DNS record
           for INGRESS in "${INGRESSES[@]}"; do
-            echo "Updating DNS record for ${{ needs.build.outputs.dnsSubDomain }}.${{ needs.build.outputs.domainName }} to $AKS_INGRESS"
-            az network dns record-set cname set-record --resource-group "AMU_DNS_RG" --zone-name "${{ needs.build.outputs.domainName }}" --record-set-name "${{ needs.build.outputs.dnsSubDomain }}" --cname "${AKS_INGRESS}" --ttl 3600
+            echo "Updating DNS record for ${INGRESS} to $AKS_INGRESS"
+            az network dns record-set cname set-record --resource-group "AMU_DNS_RG" --zone-name "${{ needs.build.outputs.domainName }}" --record-set-name "${INGRESS}" --cname "${AKS_INGRESS}" --ttl 3600
           done
 
       - name: Create Sentry release

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -179,7 +179,7 @@ jobs:
           $environmentIngress = "${{ inputs.environmentIngress }}" -replace '"', '' -replace "'", ""
           if (($appConfig.schemaVersion -eq "2") -or ($chartConfig.version -ge "2.0.0")) {
               $ingress = ($appConfig.ingress | Where-Object { $_.Name -eq "ingress" }).host
-              if (($appConfig.ingress.redirectToWWW -eq $true) -and ($environment -eq "production") -and ($environmentIngress -ne "true")) {
+              if (($appConfig.ingress.redirectToWWW -eq $true) -and ($appEnvironment -eq "production") -and ($environmentIngress -ne "true")) {
                   $wwwIngress = $true
               }
           }

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -176,8 +176,12 @@ jobs:
           Write-Output "release=$release" >> $env:GITHUB_ENV
 
           # Set ingress
+          $environmentIngress = "${{ inputs.environmentIngress }}" -replace '"', '' -replace "'", ""
           if (($appConfig.schemaVersion -eq "2") -or ($chartConfig.version -ge "2.0.0")) {
               $ingress = ($appConfig.ingress | Where-Object { $_.Name -eq "ingress" }).host
+              if (($appConfig.ingress.redirectToWWW -eq $true) -and ($environment -eq "production") -and ($environmentIngress -ne "true")) {
+                  $wwwIngress = $true
+              }
           }
           else {
               $ingress = $appConfig.ingress.host
@@ -209,6 +213,7 @@ jobs:
           Write-Output "dnsSubDomain=$dnsSubDomain" >> $env:GITHUB_ENV
           Write-Output "ingress=$ingress"
           Write-Output "ingress=$ingress" >> $env:GITHUB_ENV
+          Write-Output "wwwIngress=$wwwIngress" >> $env:GITHUB_ENV
 
       - name: Generate .env file from Azure Key Vaults
         id: get-envs
@@ -279,6 +284,7 @@ jobs:
       release: ${{ env.release }}
       maxReplicas: ${{ env.maxReplicas }}
       chartsPath: ${{ env.chartsPath }}
+      wwwIngress: ${{ env.wwwIngress }}
 
   deploy:
     name: AKS Deploy
@@ -678,16 +684,28 @@ jobs:
       - name: Create or Update Public DNS Record
         id: dns
         run: |
+          # Set AKS cluster ingress
           if [ "${{ inputs.environmentNamespace }}" == "true" ]; then
             INGRESS="${{ secrets.azureClusterName }}-${{ inputs.environment }}"
           else
             INGRESS="${{ secrets.azureClusterName }}"
           fi
           AKS_INGRESS="${INGRESS}-ingress.centralus.cloudapp.azure.com."
-          echo "Updating DNS record for ${{ needs.build.outputs.dnsSubDomain }}.${{ needs.build.outputs.domainName }} to $AKS_INGRESS"
-          az network dns record-set cname set-record --resource-group "AMU_DNS_RG" --zone-name "${{ needs.build.outputs.domainName }}" --record-set-name "${{ needs.build.outputs.dnsSubDomain }}" --cname "${AKS_INGRESS}" --ttl 3600
-
           echo "aksIngress=${AKS_INGRESS}" >> $GITHUB_OUTPUT
+
+          # Add www ingress if needed
+          WWWINGRESS = "${{ needs.build.outputs.wwwIngress }}"
+          if [ "${WWWINGRESS}" == "true" ]; then
+            INGRESSES=("www.${{ needs.build.outputs.dnsSubDomain }}.${{ needs.build.outputs.domainName }}" "${{ needs.build.outputs.dnsSubDomain }}.${{ needs.build.outputs.domainName }}")
+          else
+            INGRESSES=("${{ needs.build.outputs.dnsSubDomain }}.${{ needs.build.outputs.domainName }}")
+          fi
+
+          # Update DNS record
+          for INGRESS in "${INGRESSES[@]}"; do
+            echo "Updating DNS record for ${{ needs.build.outputs.dnsSubDomain }}.${{ needs.build.outputs.domainName }} to $AKS_INGRESS"
+            az network dns record-set cname set-record --resource-group "AMU_DNS_RG" --zone-name "${{ needs.build.outputs.domainName }}" --record-set-name "${{ needs.build.outputs.dnsSubDomain }}" --cname "${AKS_INGRESS}" --ttl 3600
+          done
 
       - name: Create Sentry release
         if: env.NEXT_PUBLIC_SENTRY_DSN && inputs.publishSentryRelease == 'true'

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -331,9 +331,6 @@ jobs:
           if (($appConfig.schemaVersion -eq "2") -or ($chartConfig.version -ge "2.0.0")) {
               $updatedIngress = @()
               foreach ($item in $appConfig.ingress) {
-                  # Set redirectToWWW to false by default
-                  $redirectToWWW = $false
-
                   # Skip setting www redirect ingress if not production
                   if (($item.name -eq "wwwredirect") -and ($environment -ne "production")) {
                       Write-Output "Skipping www redirect for $($item.name)"

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -176,7 +176,7 @@ jobs:
           Write-Output "release=$release" >> $env:GITHUB_ENV
 
           # Set ingress
-          if (($appConfig.schemaVersion -eq "2") -or ($chartConfig.version -gt "2.0.0")) {
+          if (($appConfig.schemaVersion -eq "2") -or ($chartConfig.version -ge "2.0.0")) {
               $ingress = ($appConfig.ingress | Where-Object { $_.Name -eq "ingress" }).host
           }
           else {
@@ -321,7 +321,7 @@ jobs:
           $serviceIngressWhitelist = "${{ inputs.serviceIngressWhitelist }}"
           $clusterIssuer = "letsencrypt-prod"
 
-          if (($appConfig.schemaVersion -eq "2") -or ($chartConfig.version -gt "2.0.0")) {
+          if (($appConfig.schemaVersion -eq "2") -or ($chartConfig.version -ge "2.0.0")) {
               $updatedIngress = @()
               foreach ($item in $appConfig.ingress) {
                   # Set redirectToWWW to false by default

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -324,6 +324,9 @@ jobs:
           if (($appConfig.schemaVersion -eq "2") -or ($chartConfig.version -gt "2.0.0")) {
               $updatedIngress = @()
               foreach ($item in $appConfig.ingress) {
+                  # Set redirectToWWW to false by default
+                  $redirectToWWW = $false
+
                   # Skip setting www redirect ingress if not production
                   if (($item.name -eq "wwwredirect") -and ($environment -ne "production")) {
                       Write-Output "Skipping www redirect for $($item.name)"
@@ -371,6 +374,19 @@ jobs:
                   if ($item.name -eq "ingress") {
                       # Add WWW to ingress
                       if (($item.redirectToWWW -eq $true) -and ($environment -eq "production") -and ($environmentIngress -ne "true")) {
+                          # Add www redirect ingress
+                          $updatedIngress += [PSCustomObject]@{
+                            name = "wwwredirect"
+                            host = $item.host
+                            paths = @{
+                                path = "/(.*)"
+                                pathType = "Prefix"
+                            }
+                            ingressClassName = $item.ingressClassName
+                            annotations = @{
+                                "nginx.ingress.kubernetes.io/rewrite-target" = "https://www.$($item.host)/$1"
+                          }
+
                           Write-Output "Adding www to $($item.name) host"
                           $item.host = "www.$($item.host)"
                       }
@@ -408,7 +424,7 @@ jobs:
                   $updatedIngress += [PSCustomObject]@{
                       name = $item.name
                       host = $item.host
-                      path = $item.path
+                      paths = $item.paths
                       ingressClassName = $item.ingressClassName
                       annotations = $item.annotations
                   }

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -378,10 +378,10 @@ jobs:
                           $updatedIngress += [PSCustomObject]@{
                               name = "wwwredirect"
                               host = $item.host
-                              paths = @{
+                              paths = [
                                 - path = "/(.*)"
                                   pathType = "Prefix"
-                              }
+                              ]
                               ingressClassName = $item.ingressClassName
                               annotations = @{
                                   "nginx.ingress.kubernetes.io/rewrite-target" = "https://www.$($item.host)/$1"

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -394,6 +394,7 @@ jobs:
                               ingressClassName = $item.ingressClassName
                               annotations = @{
                                   "nginx.ingress.kubernetes.io/rewrite-target" = "https://www.$($item.host)/$1"
+                                  "cert-manager.io/cluster-issuer" = $clusterIssuer
                               }
                           }
 

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -378,10 +378,12 @@ jobs:
                           $updatedIngress += [PSCustomObject]@{
                               name = "wwwredirect"
                               host = $item.host
-                              paths = [
-                                - path = "/(.*)"
-                                  pathType = "Prefix"
-                              ]
+                              paths = @(
+                                  @{
+                                      path = "/(.*)"
+                                      pathType = "Prefix"
+                                  }
+                              )
                               ingressClassName = $item.ingressClassName
                               annotations = @{
                                   "nginx.ingress.kubernetes.io/rewrite-target" = "https://www.$($item.host)/$1"

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -386,7 +386,6 @@ jobs:
                               name = "wwwredirect"
                               host = $item.host
                               path = "/(.*)"
-                              pathType = $item.pathType
                               ingressClassName = $item.ingressClassName
                               annotations = @{
                                   "nginx.ingress.kubernetes.io/rewrite-target" = "https://www.$($item.host)/$1"
@@ -432,7 +431,6 @@ jobs:
                       name = $item.name
                       host = $item.host
                       path = $item.path
-                      pathType = $item.pathType
                       ingressClassName = $item.ingressClassName
                       annotations = $item.annotations
                   }


### PR DESCRIPTION
<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Add www redirect ingress via deploy workflows (vs having a mostly redundant ingress definition in the Helm templates/values)
- Added logic for also creating a DNS record for the `www.` subdomain instead of just the root hostname

### Result
https://test-workflow.centralus.amuniversal.com/ redirects to https://www.test-workflow.centralus.amuniversal.com/

![Screenshot 2025-04-09 at 3 16 00 PM](https://github.com/user-attachments/assets/1f54528f-7aca-4ceb-9e6d-a7586c64ce43)
![Screenshot 2025-04-09 at 3 16 37 PM](https://github.com/user-attachments/assets/2ecb99c5-500f-4aa6-9dd7-64cb08efb4c7)

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-663
- Testing environment: [![🚀 Deploy](https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/actions/workflows/deploy.yml/badge.svg?branch=story%2FDEVOPS-XXX%2Ffix-www-redirect-in-v2-schema)](https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/actions/workflows/deploy.yml)
