### PR TITLE
[DEVOPS-677] Error out if none of the Swagger JSONs are reachable

### DIFF
--- a/.github/workflows/update-azureapimanagement.yaml
+++ b/.github/workflows/update-azureapimanagement.yaml
@@ -122,6 +122,7 @@ jobs:
           }
 
           # Update API versions
+          $SwaggerReachable = $False
           1..3 | ForEach-Object {
               $version = $_
 
@@ -133,6 +134,8 @@ jobs:
 
               # Check if the versioned API exists
               if ($SwaggerJSON.StatusCode -eq 200) {
+                  $SwaggerReachable = $True
+
                   # Get Swagger JSON content
                   Write-Output "Importing API version V${version}: $SwaggerURL"
                   $SwaggerJSON = $SwaggerJSON.Content -replace "/v${version}", ""
@@ -168,6 +171,11 @@ jobs:
               else {
                   Write-Output "API version V${version} (${SwaggerURL}): $($SwaggerJSON.StatusCode) $($SwaggerJSON.StatusDescription)"
               }
+          }
+          # Error out if no Swagger JSON was reachable
+          if (-not $SwaggerReachable) {
+              Write-Error "ERROR: No Swagger JSON was reachable for any version."
+              exit 1
           }
       
       - name: Send Failed Deployment report to Teams

--- a/.github/workflows/update-azureapimanagement.yaml
+++ b/.github/workflows/update-azureapimanagement.yaml
@@ -121,59 +121,60 @@ jobs:
               $OriginalVersion = $True
           }
 
-          # Update API versions
-          $SwaggerReachable = $False
-          1..3 | ForEach-Object {
-              $version = $_
+          $SwaggerDiscoverySuccessful = $false
+          $SwaggerFileName = "swagger.json"
 
+          # Update API versions
+          $ApiVersions = 1..3
+          foreach ($version in $ApiVersions) {
               # Construct the Swagger URL for each version
               $SwaggerURL = "https://$serviceFqdn/swagger/v$version/swagger.json"
+              
+              try {
+                  # Pull down Swagger JSON
+                  $SwaggerResponse = Invoke-WebRequest -Uri $SwaggerURL -UseBasicParsing -ErrorAction Stop
 
-              # Pull down Swagger JSON
-              $SwaggerJSON = Invoke-WebRequest -Uri $SwaggerURL -SkipHttpErrorCheck
+                  # Check if the versioned API exists
+                  if ($SwaggerResponse.StatusCode -eq 200) {
+                      $SwaggerDiscoverySuccessful = $true
 
-              # Check if the versioned API exists
-              if ($SwaggerJSON.StatusCode -eq 200) {
-                  $SwaggerReachable = $True
+                      # Get Swagger JSON content
+                      Write-Output "Importing API version V${version}: $SwaggerURL"
+                      $SwaggerContent = $SwaggerResponse.Content -replace "/v${version}", ""
 
-                  # Get Swagger JSON content
-                  Write-Output "Importing API version V${version}: $SwaggerURL"
-                  $SwaggerJSON = $SwaggerJSON.Content -replace "/v${version}", ""
+                      # Generate a unique API ID for each version
+                      $versionedApiId = "$ApiId-v$version"
 
-                  # Generate a unique API ID for each version
-                  $versionedApiId = "$ApiId-v$version"
+                      # Save Swagger JSON to file
+                      $SwaggerContent | Out-File -FilePath $SwaggerFileName -Encoding utf8
 
+                      # Import the versioned API
+                      Import-AzApiManagementApi -Context $Context -SpecificationPath $SwaggerFileName -SpecificationFormat OpenApi -Path $ApiId -ApiId "$versionedApiId" -ApiVersion "v$version" -ApiVersionSetId $ApiVersionSet.Id
 
-                  # Save Swagger JSON to file
-                  $SwaggerJSONFile = "swagger.json"
-                  $SwaggerJSON | Out-File -FilePath $SwaggerJSONFile
+                      # Retrieve and update the API object
+                      $Api = Get-AzApiManagementApi -Context $Context -ApiId "$versionedApiId"
+                      $Api.ServiceURL = "$ServiceURL/v${version}"
+                      $Api.SubscriptionRequired = $ApiSubscriptionRequired
 
-                  # Import the versioned API
-                  Import-AzApiManagementApi -Context $Context -SpecificationPath $SwaggerJSONFile -SpecificationFormat OpenApi -Path $ApiId -ApiId "$versionedApiId" -ApiVersion "v$version" -ApiVersionSetId $ApiVersionSet.Id
+                      # Associate the versioned API with a product
+                      Set-AzApiManagementApi -InputObject $Api
+                      Add-AzApiManagementApiToProduct -Context $Context -ApiId "$versionedApiId" -ProductId "AZ-WebServices"
+                      if ($ApiProductId -ne "AZ-WebServices") {
+                          Add-AzApiManagementApiToProduct -Context $Context -ApiId "$versionedApiId" -ProductId $ApiProductId
+                      }
 
-                  # Retrieve and update the API object
-                  $Api = Get-AzApiManagementApi -Context $Context -ApiId "$versionedApiId"
-                  $Api.ServiceURL = "$ServiceURL/v${version}"
-                  $Api.SubscriptionRequired = $ApiSubscriptionRequired
-
-                  # Associate the versioned API with a product
-                  Set-AzApiManagementApi -InputObject $Api
-                  Add-AzApiManagementApiToProduct -Context $Context -ApiId "$versionedApiId" -ProductId "AZ-WebServices"
-                  if ($ApiProductId -ne "AZ-WebServices") {
-                      Add-AzApiManagementApiToProduct -Context $Context -ApiId "$versionedApiId" -ProductId $ApiProductId
-                  }
-
-                  # Remove the original API spec
-                  if ($OriginalVersion) {
-                      Remove-AzApiManagementApi -Context $Context -ApiId $ApiId
+                      # Remove the original API spec
+                      if ($OriginalVersion) {
+                          Remove-AzApiManagementApi -Context $Context -ApiId $ApiId
+                      }
                   }
               }
-              else {
-                  Write-Output "API version V${version} (${SwaggerURL}): $($SwaggerJSON.StatusCode) $($SwaggerJSON.StatusDescription)"
+              catch {
+                  Write-Output "API version V${version} (${SwaggerURL}): $($_.Exception.Message)"
               }
           }
           # Error out if no Swagger JSON was reachable
-          if (-not $SwaggerReachable) {
+          if (-not $SwaggerDiscoverySuccessful) {
               Write-Error "ERROR: No Swagger JSON was reachable for any version."
               exit 1
           }


### PR DESCRIPTION
<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-677" title="DEVOPS-677" target="_blank">DEVOPS-677</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>API workflows succeeding despite not importing any Swagger JSONs</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://amuniversal.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

Error out if none of the Swagger JSONs are reachable.

We have had issues the past couple of days where we moved the GitHub runners to a new cluster and the runner IPs changed and were not able to access the Swagger JSONs. The workflows ran successfully despite not importing anything to the Azure APIM instances.

Also a couple of other changes:
- More robust HTTP request to the Swagger endpoint
- Try/catch statement for more intuitive error handling
- Rename vars to be more intuitive

Result: 
<img width="1246" alt="image" src="https://github.com/user-attachments/assets/1658f419-f73a-4d25-8705-cf2c70d1cb61" />


## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-677
- Testing environment: [![🚀 Deploy](https://github.com/Andrews-McMeel-Universal/puzzle-society_service/actions/workflows/deploy.yml/badge.svg?branch=bug%2FDEVOPS-677%2Ferror-out-on-no-swagger-json-found&event=push)](https://github.com/Andrews-McMeel-Universal/puzzle-society_service/actions/runs/14602958345)
