### PR TITLE
[DEVOPS-686] Add multiple retries when pulling in Swagger JSONs

### DIFF
--- a/.github/workflows/update-azureapimanagement.yaml
+++ b/.github/workflows/update-azureapimanagement.yaml
@@ -129,50 +129,64 @@ jobs:
           foreach ($version in $ApiVersions) {
               # Construct the Swagger URL for each version
               $SwaggerURL = "https://$serviceFqdn/swagger/v$version/swagger.json"
-              
-              try {
-                  # Pull down Swagger JSON
-                  $SwaggerResponse = Invoke-WebRequest -Uri $SwaggerURL -UseBasicParsing -ErrorAction Stop
+              $attempt = 0
+              $maxRetries = 3
+              $delaySeconds = 10
+              $success = $false
 
-                  # Check if the versioned API exists
-                  if ($SwaggerResponse.StatusCode -eq 200) {
-                      $SwaggerDiscoverySuccessful = $true
-
-                      # Get Swagger JSON content
-                      Write-Output "Importing API version V${version}: $SwaggerURL"
-                      $SwaggerContent = $SwaggerResponse.Content -replace "/v${version}", ""
-
-                      # Generate a unique API ID for each version
-                      $versionedApiId = "$ApiId-v$version"
-
-                      # Save Swagger JSON to file
-                      $SwaggerContent | Out-File -FilePath $SwaggerFileName -Encoding utf8
-
-                      # Import the versioned API
-                      Import-AzApiManagementApi -Context $Context -SpecificationPath $SwaggerFileName -SpecificationFormat OpenApi -Path $ApiId -ApiId "$versionedApiId" -ApiVersion "v$version" -ApiVersionSetId $ApiVersionSet.Id
-
-                      # Retrieve and update the API object
-                      $Api = Get-AzApiManagementApi -Context $Context -ApiId "$versionedApiId"
-                      $Api.ServiceURL = "$ServiceURL/v${version}"
-                      $Api.SubscriptionRequired = $ApiSubscriptionRequired
-
-                      # Associate the versioned API with a product
-                      Set-AzApiManagementApi -InputObject $Api
-                      Add-AzApiManagementApiToProduct -Context $Context -ApiId "$versionedApiId" -ProductId "AZ-WebServices"
-                      if ($ApiProductId -ne "AZ-WebServices") {
-                          Add-AzApiManagementApiToProduct -Context $Context -ApiId "$versionedApiId" -ProductId $ApiProductId
-                      }
-
-                      # Remove the original API spec
-                      if ($OriginalVersion) {
-                          Remove-AzApiManagementApi -Context $Context -ApiId $ApiId
+              $SwaggerResponse = $null
+              while ($attempt -lt $maxRetries -and -not $success) {
+                  try {
+                      $attempt++
+                      # Pull down Swagger JSON
+                      $SwaggerResponse = Invoke-WebRequest -Uri $SwaggerURL -UseBasicParsing -ErrorAction Stop
+                      $success = $true
+                  }
+                  catch {
+                      Write-Output "Attempt $attempt for API version V${version} failed: $($_.Exception.Message)"
+                      if ($attempt -lt $maxRetries) {
+                          Write-Output "Retrying in $delaySeconds seconds..."
+                          Start-Sleep -Seconds $delaySeconds
                       }
                   }
               }
-              catch {
-                  Write-Output "API version V${version} (${SwaggerURL}): $($_.Exception.Message)"
+
+              # Check if the versioned API exists
+              if ($success -and $SwaggerResponse.StatusCode -eq 200) {
+                  $SwaggerDiscoverySuccessful = $true
+
+                  # Get Swagger JSON content
+                  Write-Output "Importing API version V${version}: $SwaggerURL"
+                  $SwaggerContent = $SwaggerResponse.Content -replace "/v${version}", ""
+
+                  # Generate a unique API ID for each version
+                  $versionedApiId = "$ApiId-v$version"
+
+                  # Save Swagger JSON to file
+                  $SwaggerContent | Out-File -FilePath $SwaggerFileName -Encoding utf8
+
+                  # Import the versioned API
+                  Import-AzApiManagementApi -Context $Context -SpecificationPath $SwaggerFileName -SpecificationFormat OpenApi -Path $ApiId -ApiId "$versionedApiId" -ApiVersion "v$version" -ApiVersionSetId $ApiVersionSet.Id
+
+                  # Retrieve and update the API object
+                  $Api = Get-AzApiManagementApi -Context $Context -ApiId "$versionedApiId"
+                  $Api.ServiceURL = "$ServiceURL/v${version}"
+                  $Api.SubscriptionRequired = $ApiSubscriptionRequired
+
+                  # Associate the versioned API with a product
+                  Set-AzApiManagementApi -InputObject $Api
+                  Add-AzApiManagementApiToProduct -Context $Context -ApiId "$versionedApiId" -ProductId "AZ-WebServices"
+                  if ($ApiProductId -ne "AZ-WebServices") {
+                      Add-AzApiManagementApiToProduct -Context $Context -ApiId "$versionedApiId" -ProductId $ApiProductId
+                  }
+
+                  # Remove the original API spec
+                  if ($OriginalVersion) {
+                      Remove-AzApiManagementApi -Context $Context -ApiId $ApiId
+                  }
               }
           }
+
           # Error out if no Swagger JSON was reachable
           if (-not $SwaggerDiscoverySuccessful) {
               Write-Error "ERROR: No Swagger JSON was reachable for any version."


### PR DESCRIPTION
<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-686" title="DEVOPS-686" target="_blank">DEVOPS-686</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>API Update workflows failing due to DNS updates taking too long</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://amuniversal.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description
![image](https://github.com/user-attachments/assets/8e84c9fb-04df-49eb-92d7-6d74a0249248)

- Add multiple retries when pulling in Swagger JSONs so that the workflow doesn't fail immediately when the K8s certs are still being deployed

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-686
