### PR TITLE
[DEVOPS-679] Add multi-key support in the Clear Azure Redis Caches workflow

### DIFF
--- a/.github/workflows/clear-azure-redis-cache.yaml
+++ b/.github/workflows/clear-azure-redis-cache.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Clear Redis Cache
         shell: pwsh
         run: |
-          $CacheKey = "${{ inputs.applicationCacheKey }}"
+          $CacheKeys = "${{ inputs.applicationCacheKey }}"
           $ResourceGroupName = "${{ inputs.resourceGroupName }}"
           $Environment = "${{ inputs.environment }}"
 
@@ -60,22 +60,26 @@ jobs:
               $RedisKey = (Get-AzRedisCacheKey -Name $RedisName -ResourceGroupName $ResourceGroupName).PrimaryKey
 
               Write-Host "Authenticating to $RedisHostname..." -ForegroundColor DarkGray
-              $RedisCommands = "AUTH $RedisKey
-              SELECT 0
-              EVAL 'return redis.call(\'del\', unpack(redis.call(\'keys\', ARGV[1])))' 0 $CacheKey"
-              Write-Host "Clearing cache key: $CacheKey" -ForegroundColor DarkGray
-              $RedisResult = $RedisCommands | redis-cli -h $RedisHostname -p $RedisPort
 
-              # Check if output from cache clearing command has correct status message
-              if ($RedisResult -match '^\d+$') {
-                  Write-Host "Successfully flushed cache for $RedisHostname" -ForegroundColor Green
-              }
-              elseif ($RedisResult -match 'Wrong number of args calling Redis command From Lua script') {
-                  Write-Host "Cache key $CacheKey missing in $RedisHostname" -ForegroundColor Yellow
-              }
-              else {
-                  Write-Host "Cache key $CacheKey status unknown in $RedisHostname" -ForegroundColor Red
-                  Write-Host "Full output: $RedisResult"
+              # Loop through cache keys
+              foreach ($Key in $CacheKeys.Split(',')) {
+                  $RedisCommands = "AUTH $RedisKey
+                  SELECT 0
+                  EVAL 'return redis.call(\'del\', unpack(redis.call(\'keys\', ARGV[1])))' 0 $Key"
+                  Write-Host "Clearing cache key: $Key" -ForegroundColor DarkGray
+                  $RedisResult = $RedisCommands | redis-cli -h $RedisHostname -p $RedisPort
+
+                  # Check if output from cache clearing command has correct status message
+                  if ($RedisResult -match '^\d+$') {
+                      Write-Host "Successfully flushed '$Key' cache key for $RedisHostname" -ForegroundColor Green
+                  }
+                  elseif ($RedisResult -match 'Wrong number of args calling Redis command From Lua script') {
+                      Write-Host "Cache key '$Key' missing in $RedisHostname" -ForegroundColor Yellow
+                  }
+                  else {
+                      Write-Host "Cache key '$Key' status unknown in $RedisHostname" -ForegroundColor Red
+                      Write-Host "Full output: $RedisResult"
+                  }
               }
           }
 


### PR DESCRIPTION
<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-679" title="DEVOPS-679" target="_blank">DEVOPS-679</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Add multi-key support to Purge Redis caches workflow</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://amuniversal.atlassian.net/images/icons/issuetypes/story.png" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

…rkflow

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Add multi-key support in the Clear Azure Redis Caches workflow

## Testing
Inputs:
- `$CacheKeys = "GC-Subscription*,TPS-Subscription*"`
- `$ResourceGroupName = "AMU_DevOps_RG"`
- `$Environment = "staging"`

Result:
![image](https://github.com/user-attachments/assets/fd21ff7d-7e57-4413-bcac-182017e66bd1)

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-679
