### PR TITLE
[DEVOPS-676] Switch to official Docker GitHub actions in AKS deploy workflow

### DIFF
--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -232,8 +232,8 @@ jobs:
         if: ${{ github.event.release.tag_name != '' }}
         id: major-release
         run: |
-            MAJOR_RELEASE=$(echo "${{ github.event.release.tag_name }}" | cut -d "." -f 1)
-            echo "major_release=${MAJOR_RELEASE}" >> $GITHUB_OUTPUT
+          MAJOR_RELEASE=$(echo "${{ github.event.release.tag_name }}" | cut -d "." -f 1)
+          echo "major_release=${MAJOR_RELEASE}" >> $GITHUB_OUTPUT
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -254,7 +254,6 @@ jobs:
           context: ${{ inputs.dockerFilePath }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             ${{ env.buildArguments }}
 

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -240,6 +240,8 @@ jobs:
             type=raw,value=stable,enable=${{ inputs.environment == 'production' }}
             type=semver,value=${{ github.event.release.tag_name }},pattern={{version}},enable=${{ github.event.release.tag_name != '' }}
             type=semver,value=${{ github.event.release.tag_name }},pattern={{major}},enable=${{ github.event.release.tag_name != '' }}
+          flavor: |
+            latest=false
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -253,6 +253,9 @@ jobs:
             az acr repository update --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}@${IMAGE_MANIFEST}" --write-enabled true
           fi
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -238,7 +238,7 @@ jobs:
             type=raw,value=${{ inputs.environment }}
             type=raw,value=latest,enable=${{ inputs.environment == 'production' }}
             type=raw,value=stable,enable=${{ inputs.environment == 'production' }}
-            type=semver,value=${{ github.event.release.tag_name }},enable=${{ github.event.release.tag_name != '' }}
+            type=semver,value=${{ github.event.release.tag_name }},pattern={{version}},enable=${{ github.event.release.tag_name != '' }}
             type=semver,value=${{ github.event.release.tag_name }},pattern={{major}},enable=${{ github.event.release.tag_name != '' }}
 
       - name: Build and push Docker image

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -262,9 +262,6 @@ jobs:
             az acr repository update --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}@${IMAGE_MANIFEST}" --write-enabled true
           fi
 
-      - name: Push Docker Image
-        run: docker push -a "${{ secrets.registryHostName }}/${{ github.event.repository.name }}"
-
       - name: Send Failed Deployment report to Teams
         if: failure() && (inputs.environment != 'development')
         uses: jdcargile/ms-teams-notification@v1.4

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -243,15 +243,6 @@ jobs:
           flavor: |
             latest=false
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: ${{ inputs.dockerFilePath }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          build-args: |
-            ${{ env.buildArguments }}
-
       - name: Enable write access if image has already been deployed
         run: |
           IMAGE_MANIFEST=$(az acr repository show --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}:${{ github.sha }}-${{ inputs.environment }}" --query "digest" -o tsv || echo "")
@@ -261,6 +252,17 @@ jobs:
             echo "Enabling write access for image manifest."
             az acr repository update --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}@${IMAGE_MANIFEST}" --write-enabled true
           fi
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.dockerFilePath }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          build-args: |
+            ${{ env.buildArguments }}
+          cache-from: type=registry,ref=${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.sha }}-${{ inputs.environment }}-buildcache
+          cache-to: type=registry,ref=${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.sha }}-${{ inputs.environment }}-buildcache,mode=max
 
       - name: Send Failed Deployment report to Teams
         if: failure() && (inputs.environment != 'development')

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -253,9 +253,6 @@ jobs:
             az acr repository update --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}@${IMAGE_MANIFEST}" --write-enabled true
           fi
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
@@ -264,8 +261,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
             ${{ env.buildArguments }}
-          cache-from: type=registry,ref=${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.sha }}-${{ inputs.environment }}-buildcache
-          cache-to: type=registry,ref=${{ secrets.registryHostName }}/${{ github.event.repository.name }}:${{ github.sha }}-${{ inputs.environment }}-buildcache,mode=max
 
       - name: Send Failed Deployment report to Teams
         if: failure() && (inputs.environment != 'development')

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -228,13 +228,6 @@ jobs:
           username: ${{ secrets.registryUserName }}
           password: ${{ secrets.registryPassword }}
 
-      - name: Get major release version
-        if: ${{ github.event.release.tag_name != '' }}
-        id: major-release
-        run: |
-          MAJOR_RELEASE=$(echo "${{ github.event.release.tag_name }}" | cut -d "." -f 1)
-          echo "major_release=${MAJOR_RELEASE}" >> $GITHUB_OUTPUT
-
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
@@ -245,8 +238,8 @@ jobs:
             type=raw,value=${{ inputs.environment }}
             type=raw,value=latest,enable=${{ inputs.environment == 'production' }}
             type=raw,value=stable,enable=${{ inputs.environment == 'production' }}
-            type=raw,value=${{ github.event.release.tag_name }},enable=${{ github.event.release.tag_name != '' }}
-            type=raw,value=${{ steps.major-release.outputs.major_release }},enable=${{ steps.major-release.outputs.major_release != '' }}
+            type=semver,value=${{ github.event.release.tag_name }},enable=${{ github.event.release.tag_name != '' }}
+            type=semver,value=${{ github.event.release.tag_name }},pattern={{major}},enable=${{ github.event.release.tag_name != '' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -266,7 +259,6 @@ jobs:
             echo "Enabling write access for image manifest."
             az acr repository update --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}@${IMAGE_MANIFEST}" --write-enabled true
           fi
-
 
       - name: Push Docker Image
         run: docker push -a "${{ secrets.registryHostName }}/${{ github.event.repository.name }}"

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -211,6 +211,15 @@ jobs:
           environment: ${{ inputs.environment }}
           environmentKeyVault: ${{ inputs.environmentKeyVault }}
           contentTypes: BuildArg Env
+          buildArgPredicate: ";"
+
+      - name: Insert new line after build arguments
+        id: insert-new-line
+        run: |
+          buildArguments=$(echo "${{ steps.get-envs.outputs.buildArguments }}" | sed 's/^ ; //g' | sed 's/; /\n/g')
+          echo 'buildArguments<<EOF' >> $GITHUB_ENV
+          echo "$buildArguments" >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
 
       - name: Login to Azure Container Registry
         uses: azure/docker-login@v2
@@ -219,11 +228,35 @@ jobs:
           username: ${{ secrets.registryUserName }}
           password: ${{ secrets.registryPassword }}
 
-      - name: Build Docker Image
+      - name: Get major release version
+        if: ${{ github.event.release.tag_name != '' }}
+        id: major-release
         run: |
-          REGISTRY_REPO="${{ secrets.registryHostName }}/${{ github.event.repository.name }}"
-          IMAGE_NAME="${REGISTRY_REPO}:${{ github.sha }}-${{ inputs.environment }}"
-          docker build ${{ steps.get-envs.outputs.buildArguments }} -t "${IMAGE_NAME}" ${{ inputs.dockerFilePath }}
+            MAJOR_RELEASE=$(echo "${{ github.event.release.tag_name }}" | cut -d "." -f 1)
+            echo "major_release=${MAJOR_RELEASE}" >> $GITHUB_OUTPUT
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.registryHostName }}/${{ github.event.repository.name }}
+          tags: |
+            type=raw,value=${{ github.sha }}-${{ inputs.environment }}
+            type=raw,value=${{ inputs.environment }}
+            type=raw,value=latest,enable=${{ inputs.environment == 'production' }}
+            type=raw,value=stable,enable=${{ inputs.environment == 'production' }}
+            type=raw,value=${{ github.event.release.tag_name }},enable=${{ github.event.release.tag_name != '' }}
+            type=raw,value=${{ steps.major-release.outputs.major_release }},enable=${{ steps.major-release.outputs.major_release != '' }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.dockerFilePath }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            ${{ env.buildArguments }}
 
       - name: Enable write access if image has already been deployed
         run: |
@@ -235,20 +268,6 @@ jobs:
             az acr repository update --name "${{ secrets.registryHostName }}" --image "${{ github.event.repository.name }}@${IMAGE_MANIFEST}" --write-enabled true
           fi
 
-      - name: Tag Docker Image
-        run: |
-          REGISTRY_REPO="${{ secrets.registryHostName }}/${{ github.event.repository.name }}"
-          IMAGE_NAME="${REGISTRY_REPO}:${{ github.sha }}-${{ inputs.environment }}"
-          if [[ "${{ inputs.environment }}" == "production" ]] ; then
-            docker tag "${IMAGE_NAME}" "${REGISTRY_REPO}:latest"
-            docker tag "${IMAGE_NAME}" "${REGISTRY_REPO}:stable"
-          fi
-          if [[ "${{ github.event.release.tag_name }}" != "" ]]; then
-            docker tag "${IMAGE_NAME}" "${REGISTRY_REPO}:${{ github.event.release.tag_name }}"
-            MAJOR_RELEASE=$(echo "${{ github.event.release.tag_name }}" | cut -d "." -f 1)
-            docker tag "${IMAGE_NAME}" "${REGISTRY_REPO}:${MAJOR_RELEASE}"
-          fi
-          docker tag "${IMAGE_NAME}" "${REGISTRY_REPO}:${{ inputs.environment }}"
 
       - name: Push Docker Image
         run: docker push -a "${{ secrets.registryHostName }}/${{ github.event.repository.name }}"


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-676" title="DEVOPS-676" target="_blank">DEVOPS-676</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Switch to official Docker GitHub actions in AKS deploy workflow</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://amuniversal.atlassian.net/images/icons/issuetypes/story.png" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Switch to official Docker GitHub actions in AKS deploy workflow instead of manually running the `docker tag` and `docker build` commands

![image](https://github.com/user-attachments/assets/c0ba00bd-7bc9-4dfa-b0d2-9cb36b3d4da8)


## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-676
- Testing environment: [![🚀 Deploy](https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/actions/workflows/deploy.yml/badge.svg?branch=story%2FDEVOPS-676%2Fdocker-github-actions&event=push)](https://github.com/Andrews-McMeel-Universal/reusable_workflows-test/actions/runs/14892943858)
