### PR TITLE
[DEVOPS-694] Fix accidental command evaluation in PR description

### DIFF
--- a/.github/workflows/ephemeral-deploy.yaml
+++ b/.github/workflows/ephemeral-deploy.yaml
@@ -65,15 +65,15 @@ jobs:
       - name: Get Jira ticket ID
         id: jira-ticket
         run: |
-          # Safely assign to local variables
-          PR_BRANCH='${{ env.githubPrBranch }}'
-          PR_TITLE='${{ env.githubPrTitle }}'
-          PR_DESC='${{ env.githubPrDescription }}'
-
           extract_jira_id() {
             input="$1"
             printf "%s\n" "$input" | grep -Eo '\b[A-Z][A-Z0-9_]+-[1-9][0-9]*' | head -n1 | tr -cd 'A-Za-z0-9_-'
           }
+
+          # Safely assign to local variables
+          PR_BRANCH='${{ env.githubPrBranch }}'
+          PR_TITLE='${{ env.githubPrTitle }}'
+          PR_DESC='${{ env.githubPrDescription }}'
 
           for var in ${PR_BRANCH} ${PR_TITLE} ${PR_DESC}; do JIRA_TICKET_ID=$(extract_jira_id "$var" | grep -E ".") && break ; done
 

--- a/.github/workflows/ephemeral-deploy.yaml
+++ b/.github/workflows/ephemeral-deploy.yaml
@@ -65,29 +65,38 @@ jobs:
       - name: Get Jira ticket ID
         id: jira-ticket
         run: |
-          sanitize() {
-            # Use parameter expansion to remove disallowed characters
-            # This keeps only A-Z, a-z, 0-9, -, and _
-            sanitized="${1//[^A-Za-z0-9_-]/}"
-            echo "$sanitized"
+          # Safely assign to local variables
+          GITHUB_PR_BRANCH='${{ env.githubPrBranch }}'
+          GITHUB_PR_TITLE='${{ env.githubPrTitle }}'
+          GITHUB_PR_DESC='${{ env.githubPrDescription }}'
+
+          extract_jira_id() {
+            input="$1"
+            printf "%s\n" "$input" | grep -Eo '\b[A-Z][A-Z0-9_]+-[1-9][0-9]*' | head -n1 | tr -cd 'A-Za-z0-9_-'
           }
 
-          PR_BRANCH=$(sanitize "$(echo '${{ env.githubPrBranch }}' | grep -Eo "\b[A-Z][A-Z0-9_]+-[1-9][0-9]*" || true)")
-          PR_TITLE=$(sanitize "$(echo '${{ env.githubPrTitle }}' | grep -Eo "\b[A-Z][A-Z0-9_]+-[1-9][0-9]*" || true)")
-          PR_DESC=$(sanitize "$(echo '${{ env.githubPrDescription }}' | grep -Eo "\b[A-Z][A-Z0-9_]+-[1-9][0-9]*" || true)")
+          # Try in order: branch, title, description
+          JIRA_TICKET_ID=$(extract_jira_id "$GITHUB_PR_BRANCH")
 
-          echo "PR branch: ${PR_BRANCH}"
-          echo "PR title: ${PR_TITLE}"
-          for var in ${PR_BRANCH} ${PR_TITLE} ${PR_DESC}; do JIRA_TICKET_ID=$(echo $var | grep -E ".") && break ; done
-          if [ -z "${JIRA_TICKET_ID}" ]; then
+          if [ -z "$JIRA_TICKET_ID" ]; then
+            JIRA_TICKET_ID=$(extract_jira_id "$GITHUB_PR_TITLE")
+          fi
+
+          if [ -z "$JIRA_TICKET_ID" ]; then
+            echo "Jira ticket not found in branch name or title, checking description..."
+            JIRA_TICKET_ID=$(extract_jira_id "$GITHUB_PR_DESC")
+          fi
+
+          if [ -z "$JIRA_TICKET_ID" ]; then
             echo "::error::A Jira issue key is missing from your branch name, pull request title, and pull request description. Please confirm it is linked properly in the pull request."
             exit 1
           fi
-          echo "Jira ticket: ${JIRA_TICKET_ID}"
-          JIRA_TICKET_ID_LC=$(echo "${JIRA_TICKET_ID}" | tr '[:upper:]' '[:lower:]')
 
-          echo "jiraTicketIdLc=${JIRA_TICKET_ID_LC}" >> $GITHUB_OUTPUT
-          echo "jiraTicketId=${JIRA_TICKET_ID}" >> $GITHUB_OUTPUT
+          echo "Jira ticket: ${JIRA_TICKET_ID}"
+          JIRA_TICKET_ID_LC=$(echo "$JIRA_TICKET_ID" | tr '[:upper:]' '[:lower:]')
+
+          echo "jiraTicketIdLc=${JIRA_TICKET_ID_LC}" >> "$GITHUB_OUTPUT"
+          echo "jiraTicketId=${JIRA_TICKET_ID}" >> "$GITHUB_OUTPUT"
 
       - name: Get Environment
         id: environment

--- a/.github/workflows/ephemeral-deploy.yaml
+++ b/.github/workflows/ephemeral-deploy.yaml
@@ -83,10 +83,10 @@ jobs:
           fi
 
           echo "Jira ticket: ${JIRA_TICKET_ID}"
-          JIRA_TICKET_ID_LC=$(echo "$JIRA_TICKET_ID" | tr '[:upper:]' '[:lower:]')
+          JIRA_TICKET_ID_LC=$(echo "${JIRA_TICKET_ID}" | tr '[:upper:]' '[:lower:]')
 
-          echo "jiraTicketIdLc=${JIRA_TICKET_ID_LC}" >> "$GITHUB_OUTPUT"
-          echo "jiraTicketId=${JIRA_TICKET_ID}" >> "$GITHUB_OUTPUT"
+          echo "jiraTicketIdLc=${JIRA_TICKET_ID_LC}" >> $GITHUB_OUTPUT
+          echo "jiraTicketId=${JIRA_TICKET_ID}" >> $GITHUB_OUTPUT
 
       - name: Get Environment
         id: environment

--- a/.github/workflows/ephemeral-deploy.yaml
+++ b/.github/workflows/ephemeral-deploy.yaml
@@ -66,26 +66,16 @@ jobs:
         id: jira-ticket
         run: |
           # Safely assign to local variables
-          GITHUB_PR_BRANCH='${{ env.githubPrBranch }}'
-          GITHUB_PR_TITLE='${{ env.githubPrTitle }}'
-          GITHUB_PR_DESC='${{ env.githubPrDescription }}'
+          PR_BRANCH='${{ env.githubPrBranch }}'
+          PR_TITLE='${{ env.githubPrTitle }}'
+          PR_DESC='${{ env.githubPrDescription }}'
 
           extract_jira_id() {
             input="$1"
             printf "%s\n" "$input" | grep -Eo '\b[A-Z][A-Z0-9_]+-[1-9][0-9]*' | head -n1 | tr -cd 'A-Za-z0-9_-'
           }
 
-          # Try in order: branch, title, description
-          JIRA_TICKET_ID=$(extract_jira_id "$GITHUB_PR_BRANCH")
-
-          if [ -z "$JIRA_TICKET_ID" ]; then
-            JIRA_TICKET_ID=$(extract_jira_id "$GITHUB_PR_TITLE")
-          fi
-
-          if [ -z "$JIRA_TICKET_ID" ]; then
-            echo "Jira ticket not found in branch name or title, checking description..."
-            JIRA_TICKET_ID=$(extract_jira_id "$GITHUB_PR_DESC")
-          fi
+          for var in ${PR_BRANCH} ${PR_TITLE} ${PR_DESC}; do JIRA_TICKET_ID=$(extract_jira_id "$var" | grep -E ".") && break ; done
 
           if [ -z "$JIRA_TICKET_ID" ]; then
             echo "::error::A Jira issue key is missing from your branch name, pull request title, and pull request description. Please confirm it is linked properly in the pull request."

--- a/.github/workflows/jira-lint.yaml
+++ b/.github/workflows/jira-lint.yaml
@@ -30,17 +30,25 @@ jobs:
       - name: Retrieve Jira issue key from PR
         id: jira-ticket
         run: |
-          sanitize() {
-            # Use parameter expansion to remove disallowed characters
-            # This keeps only A-Z, a-z, 0-9, -, and _
-            sanitized="${1//[^A-Za-z0-9_-]/}"
-            echo "$sanitized"
+          extract_jira_id() {
+            input="$1"
+            printf "%s\n" "$input" | grep -Eo '\b[A-Z][A-Z0-9_]+-[1-9][0-9]*' | head -n1 | tr -cd 'A-Za-z0-9_-'
           }
 
-          PR_BRANCH=$(sanitize "$(echo '${{ env.githubPrBranch }}' | grep -Eo "\b[A-Z][A-Z0-9_]+-[1-9][0-9]*" || true)")
-          PR_TITLE=$(sanitize "$(echo '${{ env.githubPrTitle }}' | grep -Eo "\b[A-Z][A-Z0-9_]+-[1-9][0-9]*" || true)")
+          # Safely assign to local variables
+          PR_BRANCH='${{ env.githubPrBranch }}'
+          PR_TITLE='${{ env.githubPrTitle }}'
 
-          for var in ${PR_BRANCH} ${PR_TITLE}; do JIRA_TICKET_ID=$(echo $var | grep -E ".") && break ; done
+          for var in ${PR_BRANCH} ${PR_TITLE}; do JIRA_TICKET_ID=$(extract_jira_id "$var" | grep -E ".") && break ; done
+
+          if [ -z "$JIRA_TICKET_ID" ]; then
+            echo "::error::A Jira issue key is missing from your branch name, pull request title, and pull request description. Please confirm it is linked properly in the pull request."
+            exit 1
+          fi
+
+          echo "Jira ticket: ${JIRA_TICKET_ID}"
+          echo "ticket-found=true"
+          echo "ticket-found=true" >> $GITHUB_OUTPUT
 
           if [ -z "${JIRA_TICKET_ID}" ]; then
             if [ "${{ inputs.fail-on-error }}" = "true" ]; then


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-694" title="DEVOPS-694" target="_blank">DEVOPS-694</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Ephemeral Deployment Workflow Not Parsing Jira Issue Key from PR Details</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://amuniversal.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Fix accidental command evaluation in PR description

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-694
