### PR TITLE
[DEVOPS-700] Add support for custom GitHub Runner in Next CI workflows

### DIFF
--- a/.github/workflows/next-ci.yaml
+++ b/.github/workflows/next-ci.yaml
@@ -30,6 +30,11 @@ on:
         required: false
         type: string
         default: ${{ vars.APPLICATION_CI_RUN_JEST_TESTS || 'true' }}
+      GITHUB_RUNNER:
+        required: false
+        type: string
+        description: "The type of runner to use"
+        default: ${{ vars.CUSTOM_GITHUB_RUNNER || 'azure' }}
     secrets:
       AZURE_CREDENTIALS:
         required: true
@@ -40,7 +45,7 @@ jobs:
   build:
     name: Build App
     if: ${{ github.actor != 'dependabot[bot]' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.githubRunner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -84,7 +89,7 @@ jobs:
     name: Unit Tests
     if: ${{ inputs.RUN_JEST_TESTS == 'true' }}
     needs: [build]
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.githubRunner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -114,7 +119,7 @@ jobs:
     name: Integration Tests
     if: ${{ inputs.RUN_PLAYWRIGHT_TESTS == 'true' || inputs.CHECK_SIZE_LIMIT == 'true' }}
     needs: [build]
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.githubRunner }}
     timeout-minutes: 25
     steps:
       - name: Checkout

--- a/.github/workflows/next-ci.yaml
+++ b/.github/workflows/next-ci.yaml
@@ -45,7 +45,7 @@ jobs:
   build:
     name: Build App
     if: ${{ github.actor != 'dependabot[bot]' }}
-    runs-on: ${{ inputs.githubRunner }}
+    runs-on: ${{ inputs.GITHUB_RUNNER }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -89,7 +89,7 @@ jobs:
     name: Unit Tests
     if: ${{ inputs.RUN_JEST_TESTS == 'true' }}
     needs: [build]
-    runs-on: ${{ inputs.githubRunner }}
+    runs-on: ${{ inputs.GITHUB_RUNNER }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -119,7 +119,7 @@ jobs:
     name: Integration Tests
     if: ${{ inputs.RUN_PLAYWRIGHT_TESTS == 'true' || inputs.CHECK_SIZE_LIMIT == 'true' }}
     needs: [build]
-    runs-on: ${{ inputs.githubRunner }}
+    runs-on: ${{ inputs.GITHUB_RUNNER }}
     timeout-minutes: 25
     steps:
       - name: Checkout


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-700" title="DEVOPS-700" target="_blank">DEVOPS-700</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Allow CI actions to access staging/dev game endpoints for GC UI</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://amuniversal.atlassian.net/images/icons/issuetypes/story.png" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Add support for custom GitHub Runner in Next CI workflows

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-700
