### PR TITLE
[DEVOPS-643] New input for adding HA datacenter to the K8s ingress

### DIFF
--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -381,13 +381,13 @@ jobs:
                       $subDomain = $item.host -replace "${{ needs.build.outputs.domainName }}", '' -replace "\.$", ""
                       $domainName = "${{ needs.build.outputs.domainName }}"
                       $item.host = "$subDomain.$datacenterLocation.$domainName"
-                      Write-Output "Adding datacenter location to ingress $($item.name): $($item.host)"
+                      Write-Output "Adding datacenter location to $($item.name): $($item.host)"
                   }
 
                   # Add environment to ingress
                   if ($environmentIngress -ne "false") { 
                       $item.host = "$environment.$($item.host)"
-                      Write-Output "Adding environment to ingress $($item.name): $($item.host)"
+                      Write-Output "Adding environment to $($item.name): $($item.host)"
                   }
 
                   # Add ingressClassName to ingress

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -86,6 +86,11 @@ on:
         type: string
         description: "Publish Sentry release"
         default: ${{ vars.PUBLISH_SENTRY_RELEASE || 'true' }}
+      haHostname:
+        required: false
+        type: string
+        description: "The hostname for the high availability service"
+        default: ${{ vars.HA_HOSTNAME || 'false' }}
     secrets:
       azureClusterName:
         required: true
@@ -320,6 +325,7 @@ jobs:
 
           $webAuthentication = "${{ inputs.webAuthentication }}" -replace '"', '' -replace "'", ""
           $environmentIngress = "${{ inputs.environmentIngress }}" -replace '"', '' -replace "'", ""
+          $haHostname = "${{ inputs.haHostname }}" -replace '"', '' -replace "'", ""
           $adminIngressWhitelist = "${{ inputs.adminIngressWhitelist }}"
           $serviceIngressWhitelist = "${{ inputs.serviceIngressWhitelist }}"
           $clusterIssuer = "letsencrypt-prod"
@@ -366,6 +372,13 @@ jobs:
                   # Add environment to ingress
                   if ($environmentIngress -ne "false") { 
                       $item.host = "$environment.$($item.host)"
+                      Write-Output "Updating ingress host for $($item.name) to: $($item.host)"
+                  }
+
+                  # Add datacenter location to ingress if HA hostname is enabled
+                  $datacenterLocation = (az aks list --query "[?name == '${{ secrets.azureClusterName }}'].location" -o tsv)
+                  if ($haHostname -eq "true") {
+                      $item.host = "$($item.host).$datacenterLocation"
                       Write-Output "Updating ingress host for $($item.name) to: $($item.host)"
                   }
 

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -305,6 +305,11 @@ jobs:
         run: |
           Install-Module -Name powershell-yaml -Force
 
+      - name: Login via Az module
+        uses: azure/login@v2
+        with:
+          creds: "${{ secrets.azureCredentials }}"
+
       - name: Create values override file
         id: values-override
         shell: pwsh
@@ -369,16 +374,16 @@ jobs:
                       $ingressWhitelist = "0.0.0.0/0"
                   }
 
-                  # Add environment to ingress
-                  if ($environmentIngress -ne "false") { 
-                      $item.host = "$environment.$($item.host)"
-                      Write-Output "Updating ingress host for $($item.name) to: $($item.host)"
-                  }
-
                   # Add datacenter location to ingress if HA hostname is enabled
                   if ($haHostname -eq "true") {
                       $datacenterLocation = (az aks list --query "[?name == '${{ secrets.azureClusterName }}'].location" -o tsv || "centralus").ToLower()
                       $item.host = "$($item.host).$datacenterLocation"
+                      Write-Output "Updating ingress host for $($item.name) to: $($item.host)"
+                  }
+
+                  # Add environment to ingress
+                  if ($environmentIngress -ne "false") { 
+                      $item.host = "$environment.$($item.host)"
                       Write-Output "Updating ingress host for $($item.name) to: $($item.host)"
                   }
 

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -377,7 +377,10 @@ jobs:
                   # Add datacenter location to ingress if HA hostname is enabled
                   if ($haHostname -eq "true") {
                       $datacenterLocation = (az aks list --query "[?name == '${{ secrets.azureClusterName }}'].location" -o tsv || "centralus").ToLower()
-                      $item.host = "$($item.host)$datacenterLocation"
+
+                      $subDomain = $item.host -replace "${{ needs.build.outputs.domainName }}", '' -replace "\.$", ""
+                      $domainName = "${{ needs.build.outputs.domainName }}"
+                      $item.host = "$subDomain.$datacenterLocation.$domainName"
                       Write-Output "Adding datacenter location to ingress $($item.name): $($item.host)"
                   }
 

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -376,8 +376,8 @@ jobs:
                   }
 
                   # Add datacenter location to ingress if HA hostname is enabled
-                  $datacenterLocation = (az aks list --query "[?name == '${{ secrets.azureClusterName }}'].location" -o tsv)
                   if ($haHostname -eq "true") {
+                      $datacenterLocation = (az aks list --query "[?name == '${{ secrets.azureClusterName }}'].location" -o tsv || "centralus").ToLower()
                       $item.host = "$($item.host).$datacenterLocation"
                       Write-Output "Updating ingress host for $($item.name) to: $($item.host)"
                   }

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -377,14 +377,14 @@ jobs:
                   # Add datacenter location to ingress if HA hostname is enabled
                   if ($haHostname -eq "true") {
                       $datacenterLocation = (az aks list --query "[?name == '${{ secrets.azureClusterName }}'].location" -o tsv || "centralus").ToLower()
-                      $item.host = "$($item.host).$datacenterLocation"
-                      Write-Output "Updating ingress host for $($item.name) to: $($item.host)"
+                      $item.host = "$($item.host)$datacenterLocation"
+                      Write-Output "Adding datacenter location to ingress $($item.name): $($item.host)"
                   }
 
                   # Add environment to ingress
                   if ($environmentIngress -ne "false") { 
                       $item.host = "$environment.$($item.host)"
-                      Write-Output "Updating ingress host for $($item.name) to: $($item.host)"
+                      Write-Output "Adding environment to ingress $($item.name): $($item.host)"
                   }
 
                   # Add ingressClassName to ingress

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -86,11 +86,11 @@ on:
         type: string
         description: "Publish Sentry release"
         default: ${{ vars.PUBLISH_SENTRY_RELEASE || 'true' }}
-      haHostname:
+      haIngress:
         required: false
         type: string
-        description: "The hostname for the high availability service"
-        default: ${{ vars.HA_HOSTNAME || 'false' }}
+        description: "Enable high availability hostname for ingress (ingress with datacenter location)"
+        default: ${{ vars.HA_INGRESS || 'false' }}
     secrets:
       azureClusterName:
         required: true
@@ -306,7 +306,7 @@ jobs:
           Install-Module -Name powershell-yaml -Force
 
       - name: Login via Az module
-        if: inputs.haHostname == 'true'
+        if: inputs.haIngress == 'true'
         uses: azure/login@v2
         with:
           creds: "${{ secrets.azureCredentials }}"
@@ -331,7 +331,7 @@ jobs:
 
           $webAuthentication = "${{ inputs.webAuthentication }}" -replace '"', '' -replace "'", ""
           $environmentIngress = "${{ inputs.environmentIngress }}" -replace '"', '' -replace "'", ""
-          $haHostname = "${{ inputs.haHostname }}" -replace '"', '' -replace "'", ""
+          $haIngress = "${{ inputs.haIngress }}" -replace '"', '' -replace "'", ""
           $adminIngressWhitelist = "${{ inputs.adminIngressWhitelist }}"
           $serviceIngressWhitelist = "${{ inputs.serviceIngressWhitelist }}"
           $clusterIssuer = "letsencrypt-prod"
@@ -376,7 +376,7 @@ jobs:
                   }
 
                   # Add datacenter location to ingress if HA hostname is enabled
-                  if ($haHostname -eq "true") {
+                  if ($haIngress -eq "true") {
                       $datacenterLocation = (az aks list --query "[?name == '${{ secrets.azureClusterName }}'].location" -o tsv || "centralus").ToLower()
 
                       $subDomain = $item.host -replace "${{ needs.build.outputs.domainName }}", '' -replace "\.$", ""

--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -306,6 +306,7 @@ jobs:
           Install-Module -Name powershell-yaml -Force
 
       - name: Login via Az module
+        if: inputs.haHostname == 'true'
         uses: azure/login@v2
         with:
           creds: "${{ secrets.azureCredentials }}"


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-643" title="DEVOPS-643" target="_blank">DEVOPS-643</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Add Helm template support for HA datacenters to be used with Azure Front Doors </td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://amuniversal.atlassian.net/images/icons/issuetypes/story.png" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Development Env</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

We have sites that have their primary datacenter location hardcoded in their K8s ingress hostname (their respective `values.yaml` file), for example "development.centralus.gocomics.com". 

These changes are to add support using a repository variable to toggle automatically adding in the datacenter location of the Kubernetes cluster into the K8s ingress without having to manually add it in in the `values.yaml` files.

Changes:
- New input for adding HA datacenter to the K8s ingress

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-643
