### PR TITLE
[DEVOPS-717] Make the `DOTNET_LIBRARIES` repo variable as the default for the libraries input

### DIFF
--- a/.github/workflows/publish-nuget-package.yaml
+++ b/.github/workflows/publish-nuget-package.yaml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Push ${{ steps.project-name.outputs.projectName }} Package
         if: ${{ ! inputs.libraries }}
-        working-directory: "${{ steps.project-name.outputs.projectName }}/"
+        working-directory: "${{ steps.project-name.outputs.projectName }}/bin/Release/"
         run: dotnet nuget push "*.nupkg" --api-key "${{ secrets.GITHUB_TOKEN }}" --source "https://nuget.pkg.github.com/andrews-mcmeel-universal/index.json" --skip-duplicate
 
       - name: Push ${{ steps.project-name.outputs.projectName }} Packages
@@ -76,6 +76,6 @@ jobs:
         run: |
           LIBRARIES=(${{ inputs.libraries }})
           for LIBRARY in "${LIBRARIES[@]}"; do
-            cd "${{ github.workspace }}/${{ steps.project-name.outputs.projectName }}/${LIBRARY}/"
+            cd "${{ github.workspace }}/${{ steps.project-name.outputs.projectName }}/${LIBRARY}/bin/Release/"
             dotnet nuget push "*.nupkg" --api-key "${{ secrets.GITHUB_TOKEN }}" --source "https://nuget.pkg.github.com/andrews-mcmeel-universal/index.json" --skip-duplicate
           done


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-717" title="DEVOPS-717" target="_blank">DEVOPS-717</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Shared Libraries prod deploy failing</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://amuniversal.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Make the `DOTNET_LIBRARIES` repo variable as the default for the libraries input. Fixes the SharedLibraries deploy

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-717
