### PR TITLE
[DEVOPS-728] Fix secret already exists error when creating basic auth secret

### DIFF
--- a/.github/workflows/aks-deploy.yaml
+++ b/.github/workflows/aks-deploy.yaml
@@ -683,7 +683,7 @@ jobs:
                   exit 1
               fi
           
-              if kubectl get secret | grep -q "${{ needs.build.outputs.appName }}-basic-auth"; then
+              if kubectl get secret "${{ needs.build.outputs.appName }}-basic-auth" > /dev/null 2>&1; then
                   kubectl delete secret "${{ needs.build.outputs.appName }}-basic-auth"
               fi
               htpasswd -cb auth "${{ secrets.webAuthenticationUsername }}" "${{ secrets.webAuthenticationPassword }}"


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-728" title="DEVOPS-728" target="_blank">DEVOPS-728</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Uexpress UI Staging Deploys failing when creating basic auth K8s secret</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://amuniversal.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

… secret

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Fix secret already exists error when creating basic auth secret

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-728
