### PR TITLE
[DEVOPS-860] Fix failing Ruby CI checks when webpack asset precompilation is enabled

### DIFF
--- a/.github/workflows/ruby-ci.yaml
+++ b/.github/workflows/ruby-ci.yaml
@@ -81,6 +81,8 @@ jobs:
 
       - name: Run yarn install
         uses: Andrews-McMeel-Universal/cache-yarn-install@v1
+        with:
+          enable-corepack: false
 
       - name: Run webpack assets precompilation
         run: bundle exec rake assets:precompile

--- a/.github/workflows/ruby-ci.yaml
+++ b/.github/workflows/ruby-ci.yaml
@@ -79,12 +79,12 @@ jobs:
         with:
           bundler-cache: true
 
-      - name: Run yarn install
+      - name: Run Yarn Install
         uses: Andrews-McMeel-Universal/cache-yarn-install@v1
         with:
           enable-corepack: false
 
-      - name: Run webpack assets precompilation
+      - name: Run Webpack Asset Precompilation
         run: bundle exec rake assets:precompile
 
       - name: Boot Rails server

--- a/.github/workflows/ruby-ci.yaml
+++ b/.github/workflows/ruby-ci.yaml
@@ -79,6 +79,9 @@ jobs:
         with:
           bundler-cache: true
 
+      - name: Run webpack assets precompilation
+        run: bundle exec rake assets:precompile
+
       - name: Boot Rails server
         run: |
           bundle exec rails s -b 0.0.0.0 -p 3000 &

--- a/.github/workflows/ruby-ci.yaml
+++ b/.github/workflows/ruby-ci.yaml
@@ -38,6 +38,15 @@ on:
         type: string
         description: "Check out submodules"
         default: ${{ vars.GIT_CHECKOUT_SUBMODULES }}
+      WEBPACK_ASSET_PRECOMPILATION:
+        required: false
+        type: string
+        description: "Run webpack asset precompilation step"
+        default: ${{ vars.APPLICATION_CI_WEBPACK_PRECOMPILATION || 'false' }}
+      YARN_INSTALL:
+        required: false
+        type: string
+        default: ${{ vars.APPLICATION_CI_YARN_INSTALL || 'false' }}
     secrets:
       AZURE_CREDENTIALS:
         required: true
@@ -80,11 +89,13 @@ jobs:
           bundler-cache: true
 
       - name: Run Yarn Install
+        if: ${{ inputs.YARN_INSTALL != 'false' }}
         uses: Andrews-McMeel-Universal/cache-yarn-install@v1
         with:
           enable-corepack: false
 
       - name: Run Webpack Asset Precompilation
+        if: ${{ inputs.WEBPACK_ASSET_PRECOMPILATION != 'false' }}
         run: bundle exec rake assets:precompile
 
       - name: Boot Rails server

--- a/.github/workflows/ruby-ci.yaml
+++ b/.github/workflows/ruby-ci.yaml
@@ -79,6 +79,9 @@ jobs:
         with:
           bundler-cache: true
 
+      - name: Run yarn install
+        uses: Andrews-McMeel-Universal/cache-yarn-install@v1
+
       - name: Run webpack assets precompilation
         run: bundle exec rake assets:precompile
 


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-860" title="DEVOPS-860" target="_blank">DEVOPS-860</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>The Far Side GitHub PR CI Checks are failing</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://amuniversal.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Fix failing Ruby CI checks when webpack asset precompilation is enabled

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-860
- Testing environment: [![✅ Application CI](https://github.com/Andrews-McMeel-Universal/the-far-side/actions/workflows/ci.yml/badge.svg)](https://github.com/Andrews-McMeel-Universal/the-far-side/actions/runs/24463862809/job/71486960312)