### PR TITLE
[DEVOPS-861] Ignore lighthouse manifest output actionlint error

### DIFF
--- a/.github/workflows/simple-lint.yaml
+++ b/.github/workflows/simple-lint.yaml
@@ -121,5 +121,5 @@ jobs:
         shell: bash
 
       - name: Lint workflow files
-        run: ${{ steps.get_actionlint.outputs.executable }} -color -ignore "SC2086" -ignore "SC2129"
+        run: ${{ steps.get_actionlint.outputs.executable }} -color -ignore "SC2086" -ignore "SC2129" -ignore 'property "manifest" is not defined in object type'
         shell: bash


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-861" title="DEVOPS-861" target="_blank">DEVOPS-861</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Action Lint workflow failing due to false positive error</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://amuniversal.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Ignore lighthouse manifest output actionlint error

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-861
