### PR TITLE
[GOCOMICS-4047] Multiple IP addresses in Ephemeral Deployment whitelist

### DIFF
--- a/.github/workflows/ephemeral-deploy.yaml
+++ b/.github/workflows/ephemeral-deploy.yaml
@@ -37,7 +37,7 @@ on:
         required: false
         type: string
         description: "IP address that will be allowed to access the ephemeral deployment"
-        default: "207.67.20.252/32"
+        default: ${{ vars.EPHEMERAL_DEPLOYMENT_INGRESS_WHITELIST || '207.67.20.252/32' }}
       githubRunner:
         required: false
         type: string
@@ -251,8 +251,22 @@ jobs:
           az containerapp update --name "${{ needs.prepare.outputs.containerAppName }}" --resource-group "${{ inputs.clusterResourceGroup }}" --min-replicas 1
 
       - name: Add access restrictions to Container App ingress
+        env:
+          INGRESS_WHITELIST: ${{ inputs.ingressWhitelist }}
+          APP_NAME: ${{ needs.prepare.outputs.containerAppName }}
+          CLUSTER_RESOURCE_GROUP: ${{ inputs.clusterResourceGroup }}
         run: |
-          az containerapp ingress access-restriction set --action Allow --ip-address "${{ inputs.ingressWhitelist }}" --rule-name allow-range --name "${{ needs.prepare.outputs.containerAppName }}" --resource-group "${{ inputs.clusterResourceGroup }}"
+          WHITELIST_IPS=($(echo ${INGRESS_WHITELIST} | tr "," "\n"))
+          IP_INDEX=0
+          for IP in ${WHITELIST_IPS[@]}; do
+            IP_INDEX=$(expr $IP_INDEX + 1)
+            if [[ "${IP}" == "207.67.20.252/32" ]]; then
+              RULE_NAME="allow-range"
+            else
+              RULE_NAME="allow-range ${IP_INDEX}"
+            fi
+            az containerapp ingress access-restriction set --action Allow --ip-address "${IP}" --rule-name "${RULE_NAME}" --name "${APP_NAME}" --resource-group "${CLUSTER_RESOURCE_GROUP}"
+          done
 
       - name: Get Container App Hostname
         id: hostname

--- a/.github/workflows/ephemeral-deploy.yaml
+++ b/.github/workflows/ephemeral-deploy.yaml
@@ -259,7 +259,7 @@ jobs:
           IFS=' ' read -r -a WHITELIST_IPS <<< "$(echo ${INGRESS_WHITELIST} | tr ',' ' ')"
           IP_INDEX=0
           for IP in "${WHITELIST_IPS[@]}"; do
-            IP_INDEX=$(($IP_INDEX + 1))
+            IP_INDEX=$((IP_INDEX + 1))
             if [[ "${IP}" == "207.67.20.252/32" ]]; then
               RULE_NAME="allow-range"
             else

--- a/.github/workflows/ephemeral-deploy.yaml
+++ b/.github/workflows/ephemeral-deploy.yaml
@@ -256,10 +256,10 @@ jobs:
           APP_NAME: ${{ needs.prepare.outputs.containerAppName }}
           CLUSTER_RESOURCE_GROUP: ${{ inputs.clusterResourceGroup }}
         run: |
-          WHITELIST_IPS=($(echo ${INGRESS_WHITELIST} | tr "," "\n"))
+          IFS=' ' read -r -a WHITELIST_IPS <<< "$(echo ${INGRESS_WHITELIST} | tr ',' ' ')"
           IP_INDEX=0
-          for IP in ${WHITELIST_IPS[@]}; do
-            IP_INDEX=$(expr $IP_INDEX + 1)
+          for IP in "${WHITELIST_IPS[@]}"; do
+            IP_INDEX=$((${IP_INDEX} + 1))
             if [[ "${IP}" == "207.67.20.252/32" ]]; then
               RULE_NAME="allow-range"
             else

--- a/.github/workflows/ephemeral-deploy.yaml
+++ b/.github/workflows/ephemeral-deploy.yaml
@@ -259,7 +259,7 @@ jobs:
           IFS=' ' read -r -a WHITELIST_IPS <<< "$(echo ${INGRESS_WHITELIST} | tr ',' ' ')"
           IP_INDEX=0
           for IP in "${WHITELIST_IPS[@]}"; do
-            IP_INDEX=$((${IP_INDEX} + 1))
+            IP_INDEX=$(($IP_INDEX + 1))
             if [[ "${IP}" == "207.67.20.252/32" ]]; then
               RULE_NAME="allow-range"
             else


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/GOCOMICS-4047" title="GOCOMICS-4047" target="_blank">GOCOMICS-4047</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>[DevOps] Enable Dev env. for Viafoura/Raptive testing</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://amuniversal.atlassian.net/images/icons/issuetypes/story.png" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>Peer Review</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Multiple IP addresses in Ephemeral Deployment whitelist
- Maintain "allow-range" for the Boley IP since that has already been added into the ephemeral deployments in previous runs so I didn't want to add a duplicate rule that just has a different description.

<img width="551" height="265" alt="image" src="https://github.com/user-attachments/assets/b4032fed-7806-4c4b-9bb5-580b23e8f308" />


## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: GOCOMICS-4047
